### PR TITLE
Remove previous create board button from the menu

### DIFF
--- a/src/components/tasks/TaskBoardSelector.tsx
+++ b/src/components/tasks/TaskBoardSelector.tsx
@@ -84,16 +84,6 @@ export default function TaskBoardSelector() {
               <CommandItem 
                 onSelect={() => {
                   setOpen(false);
-                  setIsCreateDialogOpen(true);
-                }}
-                className="text-primary"
-              >
-                <Plus className="mr-2 h-4 w-4" />
-                Create new board
-              </CommandItem>
-              <CommandItem 
-                onSelect={() => {
-                  setOpen(false);
                   setIsImportDialogOpen(true);
                 }}
                 className="text-blue-600"


### PR DESCRIPTION
This pull request removes the "Create new board" option from the `TaskBoardSelector` component. 

Key change:

* [`src/components/tasks/TaskBoardSelector.tsx`](diffhunk://#diff-a9b001e905acd73f5e55593a4b709687af6b7f7989f9f7966de7f71109df448dL84-L93): The `CommandItem` responsible for opening the "Create new board" dialog has been removed, simplifying the UI and eliminating the ability to create a new board directly from the selector.