### PR TITLE
Add task shortlink redirect route

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -120,7 +120,13 @@ export const authOptions: AuthOptions = {
       token.role = existingUser.role.toString();
       
       return token;
-    }
+    },
+    async redirect({ url, baseUrl }) {
+      if (url.startsWith(baseUrl) || url.startsWith("/")) {
+        return url;
+      }
+      return baseUrl;
+    },
   }
 };
 

--- a/src/app/tasks/[id]/page.tsx
+++ b/src/app/tasks/[id]/page.tsx
@@ -14,8 +14,8 @@ export default async function TaskShortlinkPage({ params }: PageProps) {
 
   const { id } = params;
 
-  // Combined DB call: find task and check workspace access
-  const taskWithWorkspace = await prisma.task.findFirst({
+  // DB call: find task and check workspace access
+  const task = await prisma.task.findFirst({
     where: {
       OR: [
         { id },
@@ -37,11 +37,11 @@ export default async function TaskShortlinkPage({ params }: PageProps) {
     },
   });
 
-  if (!taskWithWorkspace) {
+  if (!task) {
     notFound();
   }
 
-  const { workspace } = taskWithWorkspace;
+  const { workspace } = task;
   const userHasAccess =
     workspace.ownerId === session.user.id ||
     workspace.members.some((member) => member.userId === session.user.id);
@@ -51,9 +51,14 @@ export default async function TaskShortlinkPage({ params }: PageProps) {
     notFound();
   }
 
+  // Check if required fields exist
+  if (!task.workspaceId || !task.taskBoardId) {
+    notFound();
+  }
+
   // Build canonical URL with URL-encoded values
-  const encodedWorkspaceId = encodeURIComponent(task.workspaceId || '');
-  const encodedTaskBoardId = encodeURIComponent(task.taskBoardId || '');
+  const encodedWorkspaceId = encodeURIComponent(task.workspaceId);
+  const encodedTaskBoardId = encodeURIComponent(task.taskBoardId);
   const encodedTaskId = encodeURIComponent(task.id);
   
   const canonicalUrl = `/${encodedWorkspaceId}/tasks?board=${encodedTaskBoardId}&taskId=${encodedTaskId}`;

--- a/src/app/tasks/[id]/page.tsx
+++ b/src/app/tasks/[id]/page.tsx
@@ -9,7 +9,8 @@ interface PageProps {
 export default async function TaskShortlinkPage({ params }: PageProps) {
   const session = await getAuthSession();
   if (!session?.user) {
-    redirect("/login");
+    const callbackUrl = `/tasks/${encodeURIComponent(params.id)}`;
+    redirect(`/login?callbackUrl=${encodeURIComponent(callbackUrl)}`);
   }
 
   const { id } = params;

--- a/src/app/tasks/[id]/page.tsx
+++ b/src/app/tasks/[id]/page.tsx
@@ -1,0 +1,39 @@
+import { notFound, redirect } from "next/navigation";
+import { prisma } from "@/lib/prisma";
+import { getAuthSession } from "@/lib/auth";
+
+interface PageProps {
+  params: { id: string };
+}
+
+export default async function TaskShortlinkPage({ params }: PageProps) {
+  const session = await getAuthSession();
+  if (!session?.user) {
+    redirect("/login");
+  }
+
+  const { id } = params;
+
+  // Single DB call: find by id OR issueKey
+  const task = await prisma.task.findFirst({
+    where: {
+      OR: [
+        { id },
+        { issueKey: id },
+      ],
+    },
+    select: {
+      id: true,
+      workspaceId: true,
+      taskBoardId: true,
+    },
+  });
+
+  if (!task) {
+    notFound();
+  }
+
+  // Build canonical URL
+  const canonicalUrl = `/${task.workspaceId}/tasks?board=${task.taskBoardId}&taskId=${task.id}`;
+  redirect(canonicalUrl);
+} 

--- a/src/app/tasks/[id]/page.tsx
+++ b/src/app/tasks/[id]/page.tsx
@@ -16,13 +16,8 @@ export default async function TaskShortlinkPage({ params }: PageProps) {
   const { id } = params;
 
   // DB call: find task and check workspace access
-  const task = await prisma.task.findFirst({
-    where: {
-      OR: [
-        { id },
-        { issueKey: id },
-      ],
-    },
+  let task = await prisma.task.findUnique({
+    where: { id },
     include: {
       workspace: {
         select: {

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -6,14 +6,17 @@ import { toast } from "react-hot-toast";
 import { Button } from "@/components/ui/button";
 import Image from "next/image";
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 
 export default function LoginForm() {
   const [isLoading, setIsLoading] = useState(false);
+  const searchParams = useSearchParams();
+  const callbackUrl = searchParams.get("callbackUrl") || "/";
 
   const handleGoogleSignIn = async () => {
     setIsLoading(true);
     try {
-      await signIn("google", { callbackUrl: "/" });
+      await signIn("google", { callbackUrl });
     } catch (error) {
       console.error("Login error:", error);
       toast.error("Failed to sign in with Google");


### PR DESCRIPTION
Add a new dynamic route at /tasks/[id] that enables sharing short, clean task URLs. The route handles both task IDs and issue keys, automatically redirecting authenticated users to the canonical task detail page with proper workspace and board context.

Features:
- Single database query using OR condition for efficient lookup
- Authentication check with redirect to login for unauthenticated users
- Support for both task ID and issue key formats
- Immediate redirect to canonical URL (no intermediate UI)
- 404 handling for non-existent tasks

This allows the Share button to generate user-friendly links while maintaining security and proper navigation context.