### PR TITLE
Enhance task filtering in KanbanView to include issueKey/short codes

### DIFF
--- a/src/components/tasks/KanbanView.tsx
+++ b/src/components/tasks/KanbanView.tsx
@@ -106,10 +106,12 @@ export default function KanbanView() {
     if (!tasks?.length) return [];
 
     return tasks.filter(task => {
-      // Filter by search term
-      const matchesSearch = searchTerm.trim() === "" ||
-        task.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        (task.description && task.description.toLowerCase().includes(searchTerm.toLowerCase()));
+      // Filter by search term (including issueKey/short codes)
+      const searchTermLower = searchTerm.trim().toLowerCase();
+      const matchesSearch = searchTermLower === "" ||
+        task.title.toLowerCase().includes(searchTermLower) ||
+        (task.description && task.description.toLowerCase().includes(searchTermLower)) ||
+        (task.issueKey && task.issueKey.toLowerCase().includes(searchTermLower));
 
       // Filter by selected types
       const matchesType = selectedTypes.length === 0 ||


### PR DESCRIPTION
 This PR enhances the task filtering in the Kanban view to allow searching by issueKey in
  addition to the existing title and description search. This improves usability by
  enabling users to quickly find tasks using their short codes.

  Description

  The current search functionality in the KanbanView component only considers the task's
  title and description. This change extends the search to also include the issueKey,
  allowing users to find tasks by their unique identifiers (e.g., "PROJ-123").

   - Updated the filtering logic in KanbanView.tsx to include task.issueKey in the search
     condition.
   - Ensured the search is case-insensitive and trims whitespace for better matching.

  Type of change

   - [x] New feature (non-breaking change which adds functionality)

  How Has This Been Tested?

   - [x] Manual testing on the Kanban board to verify that tasks can be found by their
     issueKey.

  Checklist

   - [x] My code follows the style guidelines of this project
   - [x] I have performed a self-review of my own code
   - [x] I have commented my code, particularly in hard-to-understand areas
   - [x] I have made corresponding changes to the documentation
   - [x] My changes generate no new warnings
   - [x] New and existing unit tests pass locally with my changes
   
   

https://github.com/user-attachments/assets/f3860ea0-f4e9-4714-8495-0acb3c49e8ed

