### PR TITLE
Update auto-contributors.yml

### DIFF
--- a/.github/workflows/auto-contributors.yml
+++ b/.github/workflows/auto-contributors.yml
@@ -9,7 +9,7 @@ on:
 
 permissions:
   contents: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   add-contributor:
@@ -88,10 +88,15 @@ jobs:
           npx all-contributors add "$AUTHOR_LOGIN" "$TYPES" || true
           npx all-contributors generate
 
-      - name: Commit & push changes
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add README.md .all-contributorsrc || true
-          git commit -m "docs: add @${{ github.event.pull_request.user.login }} as contributor [skip ci]" || echo "No changes to commit"
-          git push || true
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "docs: add @${{ github.event.pull_request.user.login }} as contributor [skip ci]"
+          branch: ci/all-contrib/pr-${{ github.event.pull_request.number }}
+          title: "docs: add @${{ github.event.pull_request.user.login }} as contributor"
+          body: |
+            Automated by GitHub Actions after merging #${{ github.event.pull_request.number }}.
+            This PR updates README.md and .all-contributorsrc.
+          labels: automation, documentation
+


### PR DESCRIPTION
This pull request updates the workflow for automatically adding contributors by improving permissions and changing how contributor updates are committed. The workflow now creates a new pull request for contributor changes instead of committing directly to the default branch.

**Workflow permission changes:**

* Increased `pull-requests` permission from `read` to `write` in `.github/workflows/auto-contributors.yml` to allow creating pull requests via the workflow.

**Automation improvements:**

* Replaced the step that directly committed and pushed contributor updates with the `peter-evans/create-pull-request` GitHub Action, which creates a new pull request for the changes. This includes setting the commit message, PR title, body, and labels for better automation and traceability.