### PR TITLE
docs: add @redoh as contributor [skip ci]

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,26 @@
+{
+  "projectName": "collab",
+  "projectOwner": "Art-of-Technology",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 100,
+  "commit": false,
+  "contributors": [
+    {
+      "login": "redoh",
+      "name": "Ferit",
+      "avatar_url": "https://avatars.githubusercontent.com/u/38852479?v=4",
+      "profile": "https://github.com/redoh",
+      "contributions": [
+        "code"
+      ]
+    }
+  ],
+  "contributorsPerLine": 7,
+  "badgeTemplate": "",
+  "skipCi": true,
+  "commitConvention": "angular"
+}

--- a/README.md
+++ b/README.md
@@ -161,6 +161,19 @@ This project adheres to the [Contributor Covenant](CODE_OF_CONDUCT.md). By parti
 Thanks goes to these wonderful people:
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/redoh"><img src="https://avatars.githubusercontent.com/u/38852479?v=4?s=100" width="100px;" alt="Ferit"/><br /><sub><b>Ferit</b></sub></a><br /><a href="https://github.com/Art-of-Technology/collab/commits?author=redoh" title="Code">💻</a></td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 ## License


### PR DESCRIPTION
This pull request adds support for the All Contributors specification to the repository, enabling automated recognition of project contributors. The most important changes include the introduction of the `.all-contributorsrc` configuration file and an update to the contributors section in the `README.md`.

All Contributors integration:

* Added a new `.all-contributorsrc` configuration file to define project metadata and contributor details for automated contributor recognition.

Documentation update:

* Updated the `README.md` to include a contributors table with the first contributor, following the All Contributors format.