### PR TITLE
Refactor TaskDetailContent and MarkdownEditor components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - Tracked `.all-contributorsrc` from the repository (now managed by the workflow)
 
+## [0.2.3] - 2025-08-11
+
+### Fixed
+- **Task Detail Display**: Improved task description rendering and state management
+  - Removed unused initialDescriptionRef and related useEffect from TaskDetailContent to simplify state management
+  - Updated MarkdownEditor to immediately render content changes and synchronize editor content with the content prop
+  - Ensures accurate display of task descriptions in real-time
+
+### Technical
+- Refactored TaskDetailContent component to remove unnecessary state management complexity
+- Enhanced MarkdownEditor component with better content synchronization using useEffect
+
 ## [0.2.2] - 2025-08-08
 
 ### Added

--- a/src/components/ui/markdown-editor.tsx
+++ b/src/components/ui/markdown-editor.tsx
@@ -1083,12 +1083,16 @@ export function MarkdownEditor({
     },
   }, []); // Empty dependency array to ensure editor only initializes once
 
-  // Update editor content when content prop changes
+  function normalizeHTML(html: string): string {
+    return html.replace(/\s+/g, ' ').trim();
+  }
+
   useEffect(() => {
     if (editor && content !== undefined) {
       const currentContent = editor.getHTML();
       // Only update if the content is actually different to avoid unnecessary updates
-      if (currentContent !== content) {
+      // Normalize both current and incoming content before comparison
+      if (normalizeHTML(currentContent) !== normalizeHTML(content)) {
         editor.commands.setContent(content || '');
       }
     }

--- a/src/components/ui/markdown-editor.tsx
+++ b/src/components/ui/markdown-editor.tsx
@@ -1073,6 +1073,7 @@ export function MarkdownEditor({
         style: `min-height: ${minHeight}; max-height: ${maxHeight};`,
       }
     },
+    immediatelyRender: false,
     onUpdate: ({ editor }) => {
       // Get the full HTML content for rendering
       const html = editor.getHTML();
@@ -1081,6 +1082,17 @@ export function MarkdownEditor({
       onChange?.(html, html); // Passing html twice for compatibility, but second arg could be removed if forms are updated
     },
   }, []); // Empty dependency array to ensure editor only initializes once
+
+  // Update editor content when content prop changes
+  useEffect(() => {
+    if (editor && content !== undefined) {
+      const currentContent = editor.getHTML();
+      // Only update if the content is actually different to avoid unnecessary updates
+      if (currentContent !== content) {
+        editor.commands.setContent(content || '');
+      }
+    }
+  }, [editor, content]);
 
   // Track user typing activity
   useEffect(() => {


### PR DESCRIPTION
## 📝 Summary

- Removed unused initialDescriptionRef and related useEffect from TaskDetailContent to simplify state management.
- Updated MarkdownEditor to immediately render content changes and added a useEffect to synchronise editor content with the content prop, ensuring accurate display of task descriptions.


## 🔗 Related Issue(s)

[CLB-71](https://teams.weezboo.com/weezboo/tasks/CLB-71
)

## ✅ Test Plan

<!-- How did you test the changes? Manual/automated? -->
- [ ] Unit tests added/updated
- [ ] Application tested locally
- [ ] E2E tests run (if applicable)

## 📸 Screenshots / Demo (if applicable)


https://github.com/user-attachments/assets/3cb756b2-732a-4bf2-b08a-5f8e1acff81e


## 📋 Checklist

- [ ] Code follows the project's coding standards
- [ ] Tests pass successfully
- [ ] Documentation (README, comments) updated if needed
- [ ] I have reviewed and signed the Code of Conduct and Contribution Guidelines
