### PR TITLE
Integrate HTML sanitization for notification content

### DIFF
--- a/src/app/api/mentions/route.ts
+++ b/src/app/api/mentions/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/session";
 import { z } from "zod";
+import { sanitizeHtmlToPlainText } from "@/lib/html-sanitizer";
 
 // Validation schema for mention requests
 const mentionSchema = z.object({
@@ -9,7 +10,6 @@ const mentionSchema = z.object({
   sourceType: z.enum([
     "post",
     "comment",
-    "taskComment",
     "feature",
     "task",
     "epic",
@@ -40,6 +40,7 @@ export async function POST(req: NextRequest) {
     }
     
     const { userIds, sourceType, sourceId, content } = validationResult.data;
+    const sanitizedContent = sanitizeHtmlToPlainText(content);
     
     // Create notification promises
     const notificationPromises = userIds.map(async (userId) => {
@@ -65,7 +66,7 @@ export async function POST(req: NextRequest) {
       return prisma.notification.create({
         data: {
           type: notificationType,
-          content: content,
+          content: sanitizedContent,
           userId: userId,
           senderId: currentUser.id,
           read: false,

--- a/src/app/api/mentions/route.ts
+++ b/src/app/api/mentions/route.ts
@@ -10,6 +10,7 @@ const mentionSchema = z.object({
   sourceType: z.enum([
     "post",
     "comment",
+    "taskComment",
     "feature",
     "task",
     "epic",

--- a/src/app/api/tasks/[taskId]/approve-help/route.ts
+++ b/src/app/api/tasks/[taskId]/approve-help/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth/next";
 import { authConfig } from "@/lib/auth";
 import BoardItemActivityService from "@/lib/board-item-activity-service";
+import { sanitizeHtmlToPlainText } from "@/lib/html-sanitizer";
 
 export async function POST(
   req: Request,
@@ -106,9 +107,11 @@ export async function POST(
     await prisma.notification.create({
       data: {
         type: action === 'approve' ? "TASK_HELP_APPROVED" : "TASK_HELP_REJECTED",
-        content: action === 'approve' 
-          ? `Your help request for task "${task.title}" has been approved`
-          : `Your help request for task "${task.title}" has been rejected`,
+        content: sanitizeHtmlToPlainText(
+          action === 'approve' 
+            ? `Your help request for task "${task.title}" has been approved`
+            : `Your help request for task "${task.title}" has been rejected`
+        ),
         userId: helperId,
         senderId: session.user.id,
         taskId: taskId

--- a/src/app/api/tasks/[taskId]/request-help/route.ts
+++ b/src/app/api/tasks/[taskId]/request-help/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth/next";
 import { authConfig } from "@/lib/auth";
 import BoardItemActivityService from "@/lib/board-item-activity-service";
+import { sanitizeHtmlToPlainText } from "@/lib/html-sanitizer";
 
 export async function POST(
   req: Request,
@@ -118,7 +119,7 @@ export async function POST(
       await prisma.notification.createMany({
         data: notificationRecipients.map(recipientId => ({
           type: "TASK_HELP_REQUEST",
-          content: `${session.user.name} requested to help with task: ${task.title}`,
+          content: sanitizeHtmlToPlainText(`${session.user.name} requested to help with task: ${task.title}`),
           userId: recipientId!,
           senderId: session.user.id,
           taskId: taskId

--- a/src/components/tasks/TaskCommentForm.tsx
+++ b/src/components/tasks/TaskCommentForm.tsx
@@ -10,6 +10,7 @@ import { useCurrentUser } from "@/hooks/queries/useUser";
 import { CustomAvatar } from "@/components/ui/custom-avatar";
 import { extractMentionUserIds } from "@/utils/mentions";
 import axios from "axios";
+import { sanitizeHtmlToPlainText } from "@/lib/html-sanitizer";
 
 interface TaskCommentFormProps {
   taskId: string;
@@ -54,25 +55,6 @@ export function TaskCommentForm({
         taskId,
         content
       });
-
-      // Process mentions if there are any in the comment
-      if (newComment?.id) {
-        const mentionedUserIds = extractMentionUserIds(content);
-        
-        if (mentionedUserIds.length > 0) {
-          try {
-            await axios.post("/api/mentions", {
-              userIds: mentionedUserIds,
-              sourceType: "taskComment",
-              sourceId: newComment.id,
-              content: `mentioned you in a task comment: "${content.length > 100 ? content.substring(0, 97) + '...' : content}"`
-            });
-          } catch (error) {
-            console.error("Failed to process mentions:", error);
-            // Don't fail the comment submission if mentions fail
-          }
-        }
-      }
 
       toast({
         title: "Success",

--- a/src/components/tasks/TaskCommentReplyForm.tsx
+++ b/src/components/tasks/TaskCommentReplyForm.tsx
@@ -45,25 +45,6 @@ export function TaskCommentReplyForm({
         parentId: parentCommentId
       });
 
-      // Process mentions if there are any in the reply
-      if (newReply?.id) {
-        const mentionedUserIds = extractMentionUserIds(content);
-        
-        if (mentionedUserIds.length > 0) {
-          try {
-            await axios.post("/api/mentions", {
-              userIds: mentionedUserIds,
-              sourceType: "taskComment",
-              sourceId: newReply.id,
-              content: `mentioned you in a task comment reply: "${content.length > 100 ? content.substring(0, 97) + '...' : content}"`
-            });
-          } catch (error) {
-            console.error("Failed to process mentions:", error);
-            // Don't fail the reply submission if mentions fail
-          }
-        }
-      }
-
       toast({
         title: "Success",
         description: "Reply added successfully",

--- a/src/components/ui/unified-comment-reply-form.tsx
+++ b/src/components/ui/unified-comment-reply-form.tsx
@@ -48,25 +48,6 @@ export function UnifiedCommentReplyForm({
         parentId: parentCommentId
       });
 
-      // Process mentions if there are any in the reply
-      if (newReply?.id) {
-        const mentionedUserIds = extractMentionUserIds(content);
-        
-        if (mentionedUserIds.length > 0) {
-          try {
-            await axios.post("/api/mentions", {
-              userIds: mentionedUserIds,
-              sourceType: itemType === 'task' ? "taskComment" : "comment",
-              sourceId: newReply.id,
-              content: `mentioned you in a ${itemType} comment reply: "${content.length > 100 ? content.substring(0, 97) + '...' : content}"`
-            });
-          } catch (error) {
-            console.error("Failed to process mentions:", error);
-            // Don't fail the reply submission if mentions fail
-          }
-        }
-      }
-
       setContent("");
       onCancel();
     } catch (error) {

--- a/src/components/ui/unified-comment-reply-form.tsx
+++ b/src/components/ui/unified-comment-reply-form.tsx
@@ -41,7 +41,7 @@ export function UnifiedCommentReplyForm({
     }
 
     try {
-      const newReply = await addCommentMutation.mutateAsync({
+      await addCommentMutation.mutateAsync({
         itemType,
         itemId,
         content,

--- a/src/lib/html-sanitizer.ts
+++ b/src/lib/html-sanitizer.ts
@@ -1,0 +1,14 @@
+export function sanitizeHtmlToPlainText(input: unknown): string {
+  if (typeof input !== 'string') return '';
+  let sanitized = input;
+  // Strip HTML tags
+  sanitized = sanitized.replace(/<[^>]*>/g, '');
+  // Normalize mention tokens like @[Full Name](...) -> @First
+  sanitized = sanitized.replaceAll(/@\[([^\]]+)\]\([^\)]+\)/g, (_m, name: string) => {
+    const first = String(name).trim().split(/\s+/)[0] || name;
+    return `@${first}`;
+  });
+  // Collapse whitespace
+  sanitized = sanitized.replace(/\s+/g, ' ').trim();
+  return sanitized;
+}

--- a/src/lib/notification-service.ts
+++ b/src/lib/notification-service.ts
@@ -7,6 +7,7 @@ import {
 import { WorkspaceRole } from "@/lib/permissions";
 import { format } from "date-fns";
 import { logger } from "@/lib/logger";
+import { sanitizeHtmlToPlainText } from "@/lib/html-sanitizer";
 
 export interface TaskFollowerNotificationOptions {
   taskId: string;
@@ -643,13 +644,14 @@ export class NotificationService {
     if (mentionedUserIds.length === 0) return;
 
     try {
+      const safeContent = sanitizeHtmlToPlainText(content);
       // Create mention notifications
       const notifications = mentionedUserIds
         .filter((userId) => userId !== senderId) // Don't notify the sender
         .map((userId) => ({
           type: NotificationType.TASK_COMMENT_MENTION.toString(),
           content: `mentioned you in a task comment: "${
-            content.length > 100 ? content.substring(0, 97) + "..." : content
+            safeContent.length > 100 ? safeContent.substring(0, 97) + "..." : safeContent
           }"`,
           userId,
           senderId,


### PR DESCRIPTION
## 📝 Summary

- Added `sanitizeHtmlToPlainText` function to sanitize comment and notification content across various actions, ensuring that HTML tags are stripped and mentions are normalized.
- Updated `createComment`, `addTaskComment`, and notification creation logic to use sanitized content for improved security and consistency.
- Refactored relevant API routes to utilize sanitized content when creating notifications for mentions and task help requests.

## 🔗 Related Issue(s)

[https://teams.weezboo.com/weezboo/tasks/CLB-109](https://teams.weezboo.com/weezboo/tasks/CLB-109)

## ✅ Test Plan

<!-- How did you test the changes? Manual/automated? -->
- [ ] Unit tests added/updated
- [ ] Application tested locally
- [ ] E2E tests run (if applicable)

## 📸 Screenshots / Demo (if applicable)


https://github.com/user-attachments/assets/6b6f3412-7c4d-44bc-a956-f23ddcde7d3c



## 📋 Checklist

- [ ] Code follows the project's coding standards
- [ ] Tests pass successfully
- [ ] Documentation (README, comments) updated if needed
- [ ] I have reviewed and signed the Code of Conduct and Contribution Guidelines
