### PR TITLE
Remove Messages from Sidebar navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - Tracked `.all-contributorsrc` from the repository (now managed by the workflow)
 
+## [0.2.4] - 2025-08-11
+
+### Changed
+- **Sidebar Navigation**: Removed Messages navigation item from the main sidebar
+  - Streamlined navigation by removing the Messages link and related routing logic
+  - Users can still access messages through other navigation paths
+
 ## [0.2.3] - 2025-08-11
 
 ### Fixed

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -63,8 +63,6 @@ export default function Sidebar({ pathname = "", isCollapsed = false, toggleSide
             return urls.workspace({ workspaceSlug, path: '/bookmarks' });
           case '/profile':
             return urls.workspaceProfile({ workspaceSlug });
-          case '/messages':
-            return urls.messages(workspaceSlug);
           case '/tags':
             return urls.workspace({ workspaceSlug, path: '/tags' });
           case '/features':
@@ -135,12 +133,6 @@ export default function Sidebar({ pathname = "", isCollapsed = false, toggleSide
         href: getUrl('/profile'),
         icon: UserIcon,
         current: pathname === getUrl('/profile') || pathname === `/${workspaceId}/profile`,
-      },
-      {
-        name: "Messages",
-        href: getUrl('/messages'),
-        icon: EnvelopeIcon,
-        current: pathname === getUrl('/messages') || pathname === `/${workspaceId}/messages` || pathname.startsWith(getUrl('/messages') + '/') || pathname.startsWith(`/${workspaceId}/messages/`),
       },
       {
         name: "Tags",


### PR DESCRIPTION
## 📝 Summary

- Updated CHANGELOG to include version 0.2.4, documenting the removal of the Messages navigation item from the main sidebar.
- Modified Sidebar component to eliminate the Messages link and related routing logic, streamlining navigation while maintaining access to messages through other paths.
## 🔗 Related Issue(s)

<!-- Link any related issues. Example: Closes #123 -->
[CLB-91](https://teams.weezboo.com/weezboo/tasks/CLB-91)

## ✅ Test Plan

<!-- How did you test the changes? Manual/automated? -->
- [ ] Unit tests added/updated
- [ ] Application tested locally
- [ ] E2E tests run (if applicable)

## 📸 Screenshots / Demo (if applicable)

<!-- Add screenshots or demo recordings for UI changes. -->

<img width="282" height="508" alt="Screenshot 2025-08-11 at 14 51 01" src="https://github.com/user-attachments/assets/2a6c5c7c-193e-4ea1-b66f-81cff8bb76c7" />


## 📋 Checklist

- [ ] Code follows the project's coding standards
- [ ] Tests pass successfully
- [ ] Documentation (README, comments) updated if needed
- [ ] I have reviewed and signed the Code of Conduct and Contribution Guidelines
