### PR TITLE
Enhance query invalidation for board items across components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Improved session synchronization across browser tabs and windows
 - Updated `README.md` to include Contributors anchors compatible with All Contributors
 - Refreshed documentation for clarity and consistency: `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`
+ - **Board Items Refresh**: Enhanced query invalidation to keep Kanban data in sync
+   - `EpicDetailContent`, `MilestoneDetailContent`, and `StoryDetailContent` now invalidate board items when user-visible fields change (status, assignee, reporter, labels, title, description)
+   - `TaskDetailContent` triggers immediate refresh on task deletion and movement
 
 ### Technical
 - Added comprehensive permission validation to workspace invitation acceptance
 - Enhanced workspace member role management with automatic permission updates
 - Improved session provider architecture for better state synchronization
+ - Improved task creation and deletion hooks to refresh relevant board queries and assigned tasks widgets, ensuring consistent state across the application
 
 ### Removed
 - Tracked `.all-contributorsrc` from the repository (now managed by the workflow)

--- a/src/components/epics/EpicDetailContent.tsx
+++ b/src/components/epics/EpicDetailContent.tsx
@@ -22,6 +22,7 @@ import {
     SelectValue,
 } from "@/components/ui/select";
 import { useQueryClient } from "@tanstack/react-query";
+import { boardItemsKeys } from "@/hooks/queries/useBoardItems";
 import { StatusSelect, getStatusBadge } from "../tasks/selectors/StatusSelect";
 import { AssigneeSelect } from "../tasks/selectors/AssigneeSelect";
 import { ReporterSelect } from "../tasks/selectors/ReporterSelect";
@@ -231,14 +232,12 @@ export function EpicDetailContent({
                 onRefresh();
             }, 100);
 
-            // Invalidate TanStack Query cache for board items if status, assignee, or reporter changed
-            if ((field === 'status' || field === 'assigneeId' || field === 'reporterId') && effectiveBoardId) {
-                queryClient.invalidateQueries({ queryKey: ['boardItems', { board: effectiveBoardId }] });
-            }
-
-            // Also invalidate board items when labels are updated
-            if (field === 'labels' && effectiveBoardId) {
-                queryClient.invalidateQueries({ queryKey: ['boardItems', { board: effectiveBoardId }] });
+            // Invalidate Kanban board items when any user-visible board field changes
+            if (
+                effectiveBoardId &&
+                (field === 'status' || field === 'assigneeId' || field === 'reporterId' || field === 'labels' || field === 'title' || field === 'description')
+            ) {
+                queryClient.invalidateQueries({ queryKey: boardItemsKeys.board(effectiveBoardId) });
             }
 
             return true;
@@ -599,7 +598,7 @@ export function EpicDetailContent({
                                     onClick={() => setEditingTitle(true)}
                                 >
                                     <h1 className="text-2xl font-bold group-hover:text-primary transition-colors pr-8">
-                                        {epic.title}
+                                        {title}
                                     </h1>
                                     <PenLine className="h-4 w-4 absolute right-0 top-2 opacity-0 group-hover:opacity-100 transition-opacity text-muted-foreground group-hover:text-primary" />
                                 </div>

--- a/src/components/milestones/MilestoneDetailContent.tsx
+++ b/src/components/milestones/MilestoneDetailContent.tsx
@@ -12,6 +12,7 @@ import { useToast } from "@/hooks/use-toast";
 import { Input } from "@/components/ui/input";
 import { MarkdownEditor } from "@/components/ui/markdown-editor";
 import { useQueryClient } from "@tanstack/react-query";
+import { boardItemsKeys } from "@/hooks/queries/useBoardItems";
 import { StatusSelect, getStatusBadge } from "../tasks/selectors/StatusSelect";
 import { AssigneeSelect } from "../tasks/selectors/AssigneeSelect";
 import { ReporterSelect } from "../tasks/selectors/ReporterSelect";
@@ -210,14 +211,12 @@ export function MilestoneDetailContent({
                 onRefresh();
             }, 100);
 
-            // Invalidate TanStack Query cache for board items if status, assignee, or reporter changed
-            if ((field === 'status' || field === 'assigneeId' || field === 'reporterId') && effectiveBoardId) {
-                queryClient.invalidateQueries({ queryKey: ['boardItems', { board: effectiveBoardId }] });
-            }
-
-            // Also invalidate board items when labels are updated
-            if (field === 'labels' && effectiveBoardId) {
-                queryClient.invalidateQueries({ queryKey: ['boardItems', { board: effectiveBoardId }] });
+            // Invalidate Kanban board items when any user-visible board field changes
+            if (
+                effectiveBoardId &&
+                (field === 'status' || field === 'assigneeId' || field === 'reporterId' || field === 'labels' || field === 'title' || field === 'description')
+            ) {
+                queryClient.invalidateQueries({ queryKey: boardItemsKeys.board(effectiveBoardId) });
             }
 
             return true;
@@ -505,7 +504,7 @@ export function MilestoneDetailContent({
                                     onClick={() => setEditingTitle(true)}
                                 >
                                     <h1 className="text-2xl font-bold group-hover:text-primary transition-colors pr-8">
-                                        {milestone.title}
+                                        {title}
                                     </h1>
                                     <PenLine className="h-4 w-4 absolute right-0 top-2 opacity-0 group-hover:opacity-100 transition-opacity text-muted-foreground group-hover:text-primary" />
                                 </div>

--- a/src/components/stories/StoryDetailContent.tsx
+++ b/src/components/stories/StoryDetailContent.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/components/ui/select";
 import { storyPriorityOptions } from "@/constants/task";
 import { useQueryClient } from "@tanstack/react-query";
+import { boardItemsKeys } from "@/hooks/queries/useBoardItems";
 import { StatusSelect, getStatusBadge } from "../tasks/selectors/StatusSelect";
 import { AssigneeSelect } from "../tasks/selectors/AssigneeSelect";
 import { ReporterSelect } from "../tasks/selectors/ReporterSelect";
@@ -253,14 +254,12 @@ export function StoryDetailContent({
         onRefresh();
       }, 100);
 
-      // Invalidate TanStack Query cache for board items if status, assignee, or reporter changed
-      if ((field === 'status' || field === 'assigneeId' || field === 'reporterId') && effectiveBoardId) {
-        queryClient.invalidateQueries({ queryKey: ['boardItems', { board: effectiveBoardId }] });
-      }
-
-      // Also invalidate board items when labels are updated
-      if (field === 'labels' && effectiveBoardId) {
-        queryClient.invalidateQueries({ queryKey: ['boardItems', { board: effectiveBoardId }] });
+      // Invalidate Kanban board items when any user-visible board field changes
+      if (
+        effectiveBoardId &&
+        (field === 'status' || field === 'assigneeId' || field === 'reporterId' || field === 'labels' || field === 'title' || field === 'description')
+      ) {
+        queryClient.invalidateQueries({ queryKey: boardItemsKeys.board(effectiveBoardId) });
       }
 
       return true;
@@ -652,7 +651,7 @@ export function StoryDetailContent({
                   onClick={() => setEditingTitle(true)}
                 >
                   <h1 className="text-2xl font-bold group-hover:text-primary transition-colors pr-8">
-                    {story.title}
+                    {title}
                   </h1>
                   <PenLine className="h-4 w-4 absolute right-0 top-2 opacity-0 group-hover:opacity-100 transition-opacity text-muted-foreground group-hover:text-primary" />
                 </div>

--- a/src/components/tasks/TaskDetailContent.tsx
+++ b/src/components/tasks/TaskDetailContent.tsx
@@ -36,6 +36,9 @@ import { StatusSelect } from "./selectors/StatusSelect";
 import { useWorkspace } from "@/context/WorkspaceContext";
 import { TimeAdjustmentModal } from "@/components/tasks/TimeAdjustmentModal";
 import { TaskTabs } from "@/components/tasks/TaskTabs";
+import { useQueryClient } from "@tanstack/react-query";
+import { boardItemsKeys } from "@/hooks/queries/useBoardItems";
+import { taskKeys } from "@/hooks/queries/useTask";
 import {
   Dialog,
   DialogContent,
@@ -64,6 +67,7 @@ export function TaskDetailContent({
   onClose,
   boardId,
 }: TaskDetailContentProps) {
+  const queryClient = useQueryClient();
   const { currentWorkspace } = useWorkspace();
   const { data: session } = useSession();
   const { settings } = useWorkspaceSettings();
@@ -400,6 +404,22 @@ export function TaskDetailContent({
         throw new Error('Failed to delete task');
       }
 
+      // Invalidate queries so taskboard and lists update immediately
+      try {
+        const resolvedBoardId = (boardId || task.taskBoard?.id || "");
+        if (resolvedBoardId) {
+          queryClient.invalidateQueries({ queryKey: boardItemsKeys.board(resolvedBoardId) });
+          queryClient.invalidateQueries({ queryKey: taskKeys.board(resolvedBoardId) });
+        }
+        if (task.workspaceId) {
+          queryClient.invalidateQueries({ queryKey: taskKeys.list(task.workspaceId) });
+        }
+        queryClient.invalidateQueries({ queryKey: taskKeys.detail(task.id) });
+        queryClient.invalidateQueries({ queryKey: ['assignedTasks'] });
+      } catch (e) {
+        // No-op; invalidation best-effort
+      }
+
       toast({
         title: "Task deleted",
         description: "The task has been successfully deleted.",
@@ -408,7 +428,6 @@ export function TaskDetailContent({
       // Close modal and refresh data
       setShowDeleteModal(false);
       onClose?.();
-      refreshBoards();
 
     } catch (error) {
       console.error('Error deleting task:', error);


### PR DESCRIPTION
## 📝 Summary

- Updated EpicDetailContent, MilestoneDetailContent, and StoryDetailContent to invalidate Kanban board items when any user-visible field changes, including status, assignee, reporter, labels, title, and description.
- Refactored TaskDetailContent to ensure immediate refresh of board items upon task deletion and movement.
- Improved task creation and deletion hooks to refresh relevant board queries and assigned tasks widgets, ensuring consistent state across the application.

## 🔗 Related Issue(s)

[https://teams.weezboo.com/weezboo/tasks/CLB-115](https://teams.weezboo.com/weezboo/tasks/CLB-115
)
## ✅ Test Plan

<!-- How did you test the changes? Manual/automated? -->
- [ ] Unit tests added/updated
- [ ] Application tested locally
- [ ] E2E tests run (if applicable)

## 📸 Screenshots / Demo (if applicable)


https://github.com/user-attachments/assets/347f6ef8-6331-48d3-9b6d-e820d6d9820e



## 📋 Checklist

- [ ] Code follows the project's coding standards
- [ ] Tests pass successfully
- [ ] Documentation (README, comments) updated if needed
- [ ] I have reviewed and signed the Code of Conduct and Contribution Guidelines
