### PR TITLE
Show related message at IssueTabs and TaskTabs when time tracking disabled

### DIFF
--- a/src/components/issue/sections/IssueTabs.tsx
+++ b/src/components/issue/sections/IssueTabs.tsx
@@ -28,7 +28,9 @@ export function IssueTabs({
   const { settings } = useWorkspaceSettings();
 
   // Determine which tabs to show based on issue type and settings
-  const showSessions = settings?.timeTrackingEnabled;
+  // Always show the Time tab; the inner content will display an informative
+  // message when time tracking is disabled for the workspace.
+  const showSessions = true;
   const showHelpers = true; // Show helpers for all issues
   const showRelations = true; // Show relations for all issues
 

--- a/src/components/tasks/TaskTabs.tsx
+++ b/src/components/tasks/TaskTabs.tsx
@@ -39,7 +39,9 @@ export function BoardItemTabs({
   const { settings } = useWorkspaceSettings();
 
   // Determine which tabs to show based on item type
-  const showSessions = itemType === 'task' && settings?.timeTrackingEnabled;
+  // Always show the Sessions tab for tasks; the content will render a
+  // disabled message when workspace time tracking is turned off.
+  const showSessions = itemType === 'task';
   const showHelpers = itemType === 'task';
   const showRelations = !!itemData; // Show relations tab if itemData is provided
 

--- a/src/components/tasks/TaskWorkSessions.tsx
+++ b/src/components/tasks/TaskWorkSessions.tsx
@@ -13,7 +13,11 @@ export function TaskWorkSessions({ taskId, onRefresh }: TaskWorkSessionsProps) {
 
   // Only show if time tracking is enabled
   if (!settings?.timeTrackingEnabled) {
-    return null;
+    return (
+      <div className="border border-[#1f1f1f] rounded-lg bg-[#0a0a0a] p-8 text-center">
+        <p className="text-[#666] text-sm">Time tracking is disabled for this workspace.</p>
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
## 📝 Summary

Updated IssueTabs and TaskTabs to always display the time tracking tab, regardless of workspace settings. When time tracking is disabled, TaskWorkSessions now renders an informative message instead of hiding the tab content.

## 🔗 Related Issue(s)

[https://teams.weezboo.com/368c2c60-7be4-49b3-b269-eee3fca60684/issues/CLB-D3](https://teams.weezboo.com/368c2c60-7be4-49b3-b269-eee3fca60684/issues/CLB-D3
)
## ✅ Test Plan

<!-- How did you test the changes? Manual/automated? -->
- [ ] Unit tests added/updated
- [ ] Application tested locally
- [ ] E2E tests run (if applicable)

## 📸 Screenshots / Demo (if applicable)

<img width="787" height="598" alt="Screenshot 2025-08-20 at 1 01 20 AM" src="https://github.com/user-attachments/assets/377342ec-0bcc-4609-9e06-20788f1300bf" />


## 📋 Checklist

- [ ] Code follows the project's coding standards
- [ ] Tests pass successfully
- [ ] Documentation (README, comments) updated if needed
- [ ] I have reviewed and signed the Code of Conduct and Contribution Guidelines
