### PR TITLE
Add project status reordering API and enhance Kanban column updates

### DIFF
--- a/src/app/api/projects/[projectId]/statuses/reorder/route.ts
+++ b/src/app/api/projects/[projectId]/statuses/reorder/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth/next';
+import { authConfig } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { projectId: string } }
+) {
+  try {
+    const session = await getServerSession(authConfig);
+    if (!session?.user?.email) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { projectId } = await params;
+    const body = await request.json();
+
+    const updates = Array.isArray(body?.updates) ? body.updates : null;
+    if (!updates || updates.length === 0) {
+      return NextResponse.json({ error: 'No updates provided' }, { status: 400 });
+    }
+
+    // Verify project and access
+    const project = await prisma.project.findUnique({
+      where: { id: projectId },
+      select: { workspaceId: true }
+    });
+    if (!project) {
+      return NextResponse.json({ error: 'Project not found' }, { status: 404 });
+    }
+
+    const member = await prisma.workspaceMember.findFirst({
+      where: {
+        workspaceId: project.workspaceId,
+        user: { email: session.user.email }
+      }
+    });
+    if (!member) {
+      return NextResponse.json({ error: 'Access denied' }, { status: 403 });
+    }
+
+    // Accept either { id, order } or { name, order }
+    type Update = { id?: string; name?: string; order: number };
+    const normalized: Update[] = updates.map((u: any) => ({ id: u.id, name: u.name, order: Number(u.order) }));
+
+    await prisma.$transaction(async (tx) => {
+      for (const u of normalized) {
+        if (u.id) {
+          await tx.projectStatus.update({
+            where: { id: u.id },
+            data: { order: u.order }
+          });
+        } else if (u.name) {
+          await tx.projectStatus.updateMany({
+            where: { projectId, name: u.name },
+            data: { order: u.order }
+          });
+        }
+      }
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Error reordering project statuses:', error);
+    return NextResponse.json({ error: 'Failed to reorder statuses' }, { status: 500 });
+  }
+}
+
+

--- a/src/components/views/ViewRenderer.tsx
+++ b/src/components/views/ViewRenderer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
@@ -121,6 +121,8 @@ export default function ViewRenderer({
   const queryClient = useQueryClient();
   const router = useRouter();
   const [isNewIssueOpen, setIsNewIssueOpen] = useState(false);
+  const pendingColumnOrdersRef = useRef<Record<string, number>>({});
+  const commitColumnOrderRef = useRef<any>(null);
   
   // ViewFilters context
   const {
@@ -677,6 +679,49 @@ export default function ViewRenderer({
     }
   };
 
+  // Persist Kanban column order (project statuses) with debounce batching
+  const handleColumnUpdate = (columnId: string, updates: any) => {
+    // columnId here is the internal status name (e.g., 'in_progress')
+    if (typeof updates?.order === 'number') {
+      pendingColumnOrdersRef.current[columnId] = updates.order;
+
+      if (commitColumnOrderRef.current) {
+        clearTimeout(commitColumnOrderRef.current);
+      }
+
+      commitColumnOrderRef.current = setTimeout(async () => {
+        const orders = pendingColumnOrdersRef.current;
+        pendingColumnOrdersRef.current = {};
+
+        try {
+          const projectIdsToUpdate = (tempProjectIds.length > 0
+            ? tempProjectIds
+            : view.projects.map(p => p.id));
+
+          const updatesArray = Object.entries(orders)
+            .map(([name, order]) => ({ name, order }))
+            .sort((a, b) => a.order - b.order);
+
+          await Promise.all(projectIdsToUpdate.map((projectId) =>
+            fetch(`/api/projects/${projectId}/statuses/reorder`, {
+              method: 'PATCH',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ updates: updatesArray })
+            })
+          ));
+
+          // Refresh statuses used by Kanban columns
+          queryClient.invalidateQueries({ queryKey: ['multiple-project-statuses'] });
+
+          toast({ title: 'Columns reordered', description: 'Saved new column order' });
+        } catch (error) {
+          console.error('Failed to reorder columns:', error);
+          toast({ title: 'Error', description: 'Failed to save column order', variant: 'destructive' });
+        }
+      }, 150);
+    }
+  };
+
   const renderViewContent = () => {
     const sharedProps = {
       view: {
@@ -711,6 +756,7 @@ export default function ViewRenderer({
       onSubIssuesToggle: () => setTempShowSubIssues(prev => !prev),
       // Kanban callbacks
       onIssueUpdate: handleIssueUpdate,
+      onColumnUpdate: handleColumnUpdate,
     };
 
     switch (tempDisplayType) {


### PR DESCRIPTION


## 📝 Summary

- Implemented a new PATCH API endpoint for reordering project statuses, including authorization checks and error handling.
- Updated ViewRenderer to handle column order updates with debouncing, ensuring efficient API calls.
- Enhanced KanbanBoard to sort columns by order dynamically.
- Introduced local state management for column order in useKanbanState to optimize UI updates during drag-and-drop operations.

## 🔗 Related Issue(s)

[https://teams.weezboo.com/368c2c60-7be4-49b3-b269-eee3fca60684/issues/CLB-T135](https://teams.weezboo.com/368c2c60-7be4-49b3-b269-eee3fca60684/issues/CLB-T135
)
## ✅ Test Plan

<!-- How did you test the changes? Manual/automated? -->
- [ ] Unit tests added/updated
- [ ] Application tested locally
- [ ] E2E tests run (if applicable)

## 📸 Screenshots / Demo (if applicable)

## 📋 Checklist

- [ ] Code follows the project's coding standards
- [ ] Tests pass successfully
- [ ] Documentation (README, comments) updated if needed
- [ ] I have reviewed and signed the Code of Conduct and Contribution Guidelines
