### PR TITLE
Enhance KanbanViewRenderer to handle loading states for status grouping

### DIFF
--- a/src/components/views/renderers/KanbanViewRenderer/hooks/useKanbanState.ts
+++ b/src/components/views/renderers/KanbanViewRenderer/hooks/useKanbanState.ts
@@ -58,9 +58,15 @@ export const useKanbanState = ({
 
   // Group issues by the specified field (default to status)
   const columns = useMemo(() => {
+    // Avoid showing fallback default columns while statuses are loading for status grouping
+    const groupField = view.grouping?.field || 'status';
+    if (groupField === 'status' && isLoadingStatuses) {
+      return [] as ReturnType<typeof createColumns>;
+    }
+
     const projectStatuses = projectStatusData?.statuses || [];
     return createColumns(filteredIssues, view, projectStatuses);
-  }, [filteredIssues, view, projectStatusData]);
+  }, [filteredIssues, view, projectStatusData, isLoadingStatuses]);
 
   // Count issues for filter buttons
   const issueCounts = useMemo(() => {
@@ -360,6 +366,7 @@ export const useKanbanState = ({
     issueCounts,
     displayProperties,
     showSubIssues,
+    isLoadingStatuses,
     
     // Handlers
     handleDragStart,

--- a/src/components/views/renderers/KanbanViewRenderer/index.tsx
+++ b/src/components/views/renderers/KanbanViewRenderer/index.tsx
@@ -34,6 +34,7 @@ export default function KanbanViewRenderer(props: KanbanViewRendererProps & {
     columns,
     issueCounts,
     displayProperties,
+    isLoadingStatuses,
     
     // Handlers
     handleDragStart,
@@ -55,6 +56,11 @@ export default function KanbanViewRenderer(props: KanbanViewRendererProps & {
       {/* Kanban Board Container - Full height scrollable area */}
       <div className="h-full overflow-hidden">
         <div className="h-full p-6 overflow-hidden">
+          {isLoadingStatuses && (view.grouping?.field || 'status') === 'status' ? (
+            <div className="flex items-center justify-center h-64">
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500"></div>
+            </div>
+          ) : (
           <KanbanBoard
             columns={columns}
             issues={filteredIssues}
@@ -82,6 +88,7 @@ export default function KanbanViewRenderer(props: KanbanViewRendererProps & {
             onColumnNameChange={setNewColumnName}
             onIssueCreated={onIssueCreated || (() => {})}
           />
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 📝 Summary

- Added isLoadingStatuses prop to manage loading indicators in the Kanban view.
- Updated useKanbanState hook to prevent displaying fallback columns while statuses are loading.
- Implemented a loading spinner in the Kanban board when statuses are being fetched.

## 🔗 Related Issue(s)

[https://teams.weezboo.com/368c2c60-7be4-49b3-b269-eee3fca60684/issues/CLB-D13](https://teams.weezboo.com/368c2c60-7be4-49b3-b269-eee3fca60684/issues/CLB-D13
)

## ✅ Test Plan

<!-- How did you test the changes? Manual/automated? -->
- [ ] Unit tests added/updated
- [ ] Application tested locally
- [ ] E2E tests run (if applicable)

## 📸 Screenshots / Demo (if applicable)

## 📋 Checklist

- [ ] Code follows the project's coding standards
- [ ] Tests pass successfully
- [ ] Documentation (README, comments) updated if needed
- [ ] I have reviewed and signed the Code of Conduct and Contribution Guidelines
