### PR TITLE
Remove right border of sidebar and aligned the toggle button

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -38,12 +38,16 @@
     width: var(--sidebar-width);
     overflow: hidden;
     background: #090909;
-    border-right: 1px solid #1f1f1f;
     transition: width 200ms ease;
   }
 
   .sidebar-toggle {
+    left: calc(var(--sidebar-width) - 1px);
     transition: left 200ms ease, transform 200ms ease, background 150ms ease;
+  }
+
+  .app-sidebar[data-collapsed="true"] ~ main .sidebar-toggle {
+    left: calc(var(--sidebar-closed) - 1px);
   }
 }
 
@@ -62,7 +66,6 @@
     will-change: transform;
     z-index: 30;
     background: #090909;
-    border-right: 1px solid #1f1f1f;
   }
 
   .app-sidebar[data-open="true"] {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -42,12 +42,7 @@
   }
 
   .sidebar-toggle {
-    left: calc(var(--sidebar-width) - 1px);
     transition: left 200ms ease, transform 200ms ease, background 150ms ease;
-  }
-
-  .app-sidebar[data-collapsed="true"] ~ main .sidebar-toggle {
-    left: calc(var(--sidebar-closed) - 1px);
   }
 }
 

--- a/src/components/layout/LayoutWithSidebar.tsx
+++ b/src/components/layout/LayoutWithSidebar.tsx
@@ -99,7 +99,7 @@ export default function LayoutWithSidebar({
             className="sidebar-toggle fixed top-1/2 -translate-y-1/2 z-40 w-[24px]
                          bg-[#090909] border border-[#1f1f1f] hover:bg-[#1a1a1a]
                          text-gray-400 hover:text-white rounded-r-md rounded-l-none border-l-0 shadow-md transition-all duration-200"
-            style={{ left: sidebarLeft }}
+            style={{ left: `calc(${sidebarLeft} + 8px)` }}
             aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
           >
             {isCollapsed ? (


### PR DESCRIPTION
## 📝 Summary

Updated sidebar styling by removing the right border and repositioning the toggle button to align with the sidebar's right edge. The button now acts as a seamless protrusion from the sidebar into the content area, creating a cleaner visual separation without overlapping borders. 

## 🔗 Related Issue(s)

<!-- Link any related issues. Example: Closes #123 -->
- 

## ✅ Test Plan

<!-- How did you test the changes? Manual/automated? -->
- [ ] Unit tests added/updated
- [ ] Application tested locally
- [ ] E2E tests run (if applicable)

## 📸 Screenshots / Demo (if applicable)

**BEFORE**
<img width="429" height="1954" alt="image" src="https://github.com/user-attachments/assets/02478f9e-69c7-463d-866d-0f23d3102b75" />


**AFTER**
<img width="441" height="1940" alt="image" src="https://github.com/user-attachments/assets/fa7aa1d4-1823-462d-a442-e4ea823a3b0d" />


## 📋 Checklist

- [ ] Code follows the project's coding standards
- [ ] Tests pass successfully
- [ ] Documentation (README, comments) updated if needed
- [ ] I have reviewed and signed the Code of Conduct and Contribution Guidelines
