### PR TITLE
Refactor Calendar component to integrate default class names

### DIFF
--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -6,7 +6,7 @@ import {
   ChevronLeftIcon,
   ChevronRightIcon,
 } from "lucide-react"
-import { DayButton, DayPicker } from "react-day-picker"
+import { DayButton, DayPicker, getDefaultClassNames } from "react-day-picker"
 
 import { cn } from "@/lib/utils"
 import { Button, buttonVariants } from "@/components/ui/button"
@@ -23,12 +23,13 @@ function Calendar({
 }: React.ComponentProps<typeof DayPicker> & {
   buttonVariant?: React.ComponentProps<typeof Button>["variant"]
 }) {
+  const defaultClassNames = getDefaultClassNames()  
 
   return (
     <DayPicker
       showOutsideDays={showOutsideDays}
       className={cn(
-        "bg-background group/calendar p-3 [--cell-size:theme(spacing.8)] [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent",
+        "bg-background border group/calendar p-3 [--cell-size:theme(spacing.8)] [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent",
         String.raw`rtl:**:[.rdp-button\_next>svg]:rotate-180`,
         String.raw`rtl:**:[.rdp-button\_previous>svg]:rotate-180`,
         className
@@ -65,7 +66,7 @@ function Calendar({
           defaultClassNames.month_caption
         ),
         dropdowns: cn(
-          "w-full flex items-center text-sm font-medium justify-center h-(--cell-size) gap-1.5",
+          "w-full flex items-center text-sm font-medium justify-center h-[var(--cell-size)] gap-1.5",
           defaultClassNames.dropdowns
         ),
         dropdown_root: cn(
@@ -154,7 +155,7 @@ function Calendar({
             <ChevronDownIcon className={cn("size-4", className)} {...props} />
           )
         },
-        DayButton: DayButton,
+        DayButton: CalendarDayButton,
         WeekNumber: ({ children, ...props }) => {
           return (
             <td {...props}>


### PR DESCRIPTION
## 📝 Summary
This pull request updates the `Calendar` component in `src/components/ui/calendar.tsx` to improve its styling and make its class name handling more robust. The main changes include importing and using `getDefaultClassNames` from `react-day-picker`, fixing a CSS variable reference, and swapping out the `DayButton` component for a custom implementation.

**Styling and class name improvements:**
* Imported `getDefaultClassNames` from `react-day-picker` and used it to standardize class names within the `Calendar` component.
* Updated the CSS variable reference for cell height from `h-(--cell-size)` to the correct `h-[var(--cell-size)]` for improved compatibility and clarity.
* Added a border to the calendar container for better visual separation.

**Component customization:**
* Replaced the default `DayButton` with a custom `CalendarDayButton` to allow for more flexible button rendering within the calendar.

## 🔗 Related Issue(s)

[CLB-B10](https://teams.weezboo.com/368c2c60-7be4-49b3-b269-eee3fca60684/issues/CLB-B10)

## ✅ Test Plan

<!-- How did you test the changes? Manual/automated? -->
- [ ] Unit tests added/updated
- [ ] Application tested locally
- [ ] E2E tests run (if applicable)

## 📋 Checklist

- [ ] Code follows the project's coding standards
- [ ] Tests pass successfully
- [ ] Documentation (README, comments) updated if needed
- [ ] I have reviewed and signed the Code of Conduct and Contribution Guidelines
