### PR TITLE
Kanban Board Drag & Drop Validation Enhancement

### DIFF
--- a/src/components/views/renderers/KanbanViewRenderer/components/KanbanBoard.tsx
+++ b/src/components/views/renderers/KanbanViewRenderer/components/KanbanBoard.tsx
@@ -17,8 +17,11 @@ export default function KanbanBoard({
   projects,
   workspaceId,
   currentUserId,
+  draggedIssue,
+  hoverState,
   onDragEnd,
   onDragStart,
+  onDragUpdate,
   onIssueClick,
   onCreateIssue,
   onStartCreatingIssue,
@@ -45,7 +48,7 @@ export default function KanbanBoard({
   }
 
   return (
-    <DragDropContext onDragEnd={onDragEnd} onDragStart={onDragStart}>
+    <DragDropContext onDragEnd={onDragEnd} onDragStart={onDragStart} onDragUpdate={onDragUpdate}>
       <Droppable droppableId="board" direction="horizontal" type="column">
         {(provided) => (
           <div
@@ -67,6 +70,8 @@ export default function KanbanBoard({
                 projects={projects}
                 workspaceId={workspaceId}
                 currentUserId={currentUserId}
+                draggedIssue={draggedIssue}
+                hoverState={hoverState}
                 onIssueClick={onIssueClick}
                 onCreateIssue={onCreateIssue}
                 onStartCreatingIssue={onStartCreatingIssue}

--- a/src/components/views/renderers/KanbanViewRenderer/components/KanbanColumn.tsx
+++ b/src/components/views/renderers/KanbanViewRenderer/components/KanbanColumn.tsx
@@ -7,7 +7,8 @@ import {
   Plus,
   GripVertical,
   Check,
-  X
+  X,
+  AlertCircle
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Draggable, Droppable } from "@hello-pangea/dnd";
@@ -28,6 +29,8 @@ export default function KanbanColumn({
   projects,
   workspaceId,
   currentUserId,
+  draggedIssue,
+  hoverState,
   onIssueClick,
   onCreateIssue,
   onStartCreatingIssue,
@@ -41,6 +44,10 @@ export default function KanbanColumn({
   onColumnNameChange,
   onIssueCreated
 }: KanbanColumnProps) {
+
+  const shouldShowDisabledState = hoverState.columnId === column.id && !hoverState.canDrop;
+  const cannotDropReason = `Cannot drop issue from ${draggedIssue?.project?.name || 'different project'} here`;
+
   return (
     <Draggable key={column.id} draggableId={column.id} index={index}>
       {(provided, snapshot) => (
@@ -97,6 +104,11 @@ export default function KanbanColumn({
                   <Badge variant="secondary" className="text-xs bg-[#1f1f1f] text-[#999] border-0">
                     {column.issues.length}
                   </Badge>
+                  {shouldShowDisabledState && (
+                    <div title={cannotDropReason}>
+                      <AlertCircle className="h-4 w-4 text-red-400 ml-2" />
+                    </div>
+                  )}
                 </>
               )}
             </div>
@@ -117,10 +129,19 @@ export default function KanbanColumn({
                 ref={provided.innerRef}
                 {...provided.droppableProps}
                 className={cn(
-                  "flex-1 space-y-2 min-h-[200px] rounded-lg transition-colors overflow-y-auto",
-                  snapshot.isDraggingOver && "bg-[#1a1a1a]"
+                  "relative flex-1 space-y-2 min-h-[200px] rounded-lg transition-all duration-200 overflow-y-auto",
+                  snapshot.isDraggingOver && !shouldShowDisabledState && "bg-[#1a1a1a] border border-[#0969da]",
+                  snapshot.isDraggingOver && shouldShowDisabledState && "bg-[#1a1a1a] border border-red-500",
                 )}
               >
+                {snapshot.isDraggingOver && shouldShowDisabledState && (
+                  <div className="absolute inset-0 bg-red-700/10 z-10">
+                    <div className="flex items-center justify-center h-full">
+                      <p className="text-white text-sm">{cannotDropReason}</p>
+                    </div>
+                  </div>
+                )}
+
                 {/* Create Issue Input */}
                 {isCreatingIssue && (
                   <QuickIssueCreate
@@ -148,9 +169,13 @@ export default function KanbanColumn({
                 {provided.placeholder}
 
                 {/* Empty Column */}
-                {column.issues.length === 0 && !isCreatingIssue && (
+                {column.issues.length === 0 && !isCreatingIssue && !snapshot.isDraggingOver && (
                   <div
-                    className="flex items-center justify-center h-32 text-[#666] border-2 border-dashed border-[#2a2a2a] rounded-lg hover:border-[#0969da] transition-colors cursor-pointer"
+                    className={cn(
+                      "flex items-center justify-center h-32 text-[#666] border-2 border-dashed border-[#2a2a2a] rounded-lg transition-colors cursor-pointer",
+                      snapshot.isDraggingOver && "pointer-events-none",
+                      !snapshot.isDraggingOver && "hover:border-[#0969da]"
+                    )}
                     onClick={() => onStartCreatingIssue(column.id)}
                   >
                     <div className="text-center">

--- a/src/components/views/renderers/KanbanViewRenderer/hooks/useKanbanState.ts
+++ b/src/components/views/renderers/KanbanViewRenderer/hooks/useKanbanState.ts
@@ -34,6 +34,8 @@ export const useKanbanState = ({
   const [isCreatingIssue, setIsCreatingIssue] = useState<string | null>(null);
   const [newIssueTitle, setNewIssueTitle] = useState('');
   const [showSubIssues, setShowSubIssues] = useState(true);
+
+  const [hoverState, setHoverState] = useState<{ canDrop: boolean, columnId: string }>({ canDrop: true, columnId: '' });
   
   // Local state for immediate UI updates during drag & drop
   const [localIssues, setLocalIssues] = useState(issues);
@@ -82,13 +84,83 @@ export const useKanbanState = ({
     return countIssuesByType(issues);
   }, [issues]);
 
+  // Helper function to validate if an issue can be moved to a target column
+  const canIssueMoveTo = useCallback((issue: any, targetColumnId: string): boolean => {
+    // Allow movement within the same column (reordering)
+    if (issue.status === targetColumnId || issue.statusValue === targetColumnId) {
+      return true;
+    }
+
+    // If we don't have project statuses data, allow movement (fallback behavior)
+    if (!projectStatusData?.projectStatuses) {
+      return true;
+    }
+
+    // Find the project-specific statuses for the issue's project
+    const projectSpecificStatuses = projectStatusData.projectStatuses.filter(
+      (ps: any) => ps.projectId === issue.projectId
+    );
+
+    // If no project-specific statuses found, allow movement to common columns
+    if (projectSpecificStatuses.length === 0) {
+      return true;
+    }
+
+    // Check if the target column exists in the issue's project statuses
+    const targetStatusExists = projectSpecificStatuses.some(
+      (ps: any) => ps.name === targetColumnId
+    );
+
+    return targetStatusExists;
+  }, [projectStatusData]);
+
+  // Track the currently dragged issue and hover state for visual feedback
+  const [draggedIssue, setDraggedIssue] = useState<any>(null);
+
   // Drag and drop handlers
-  const handleDragStart = useCallback(() => {
+  const handleDragStart = useCallback((start: any) => {
     isDraggingRef.current = true;
-  }, []);
+    if (start.type === 'issue') {
+      const issue = localIssues.find((i: any) => i.id === start.draggableId);
+      setDraggedIssue(issue);
+    }
+  }, [localIssues]);
+
+  const handleDragUpdate = useCallback((update: any) => {
+    if (!update.destination) {
+      setHoverState({ canDrop: true, columnId: '' });
+      return;
+    }
+    
+    if (update.type === 'issue' && update.destination) {
+      const targetColumnId = update.destination.droppableId;
+      
+      // Find the dragged issue and check if it can be moved to the target column
+      if (draggedIssue) {
+        const canDrop = canIssueMoveTo(draggedIssue, targetColumnId);
+
+        setHoverState({ canDrop, columnId: targetColumnId });
+        console.log(`Can drop issue ${draggedIssue.id} to column ${targetColumnId}:`, canDrop);
+      }
+    } else {
+      setHoverState({ canDrop: true, columnId: '' });
+    }
+  }, [draggedIssue, canIssueMoveTo]);
 
   const handleDragEnd = useCallback(async (result: DropResult) => {
     const { destination, source, draggableId, type } = result;
+
+    if (!hoverState.canDrop) {
+      isDraggingRef.current = false;
+      setHoverState({ canDrop: true, columnId: '' });
+      toast({
+        title: "Cannot drop issue",
+        description: `Issue ${draggedIssue?.title} cannot be dropped to column ${hoverState.columnId}`,
+        variant: "destructive"
+      });
+      
+      return;
+    }
 
     if (!destination) {
       isDraggingRef.current = false;
@@ -171,8 +243,11 @@ export const useKanbanState = ({
       }
     }
     
+    // Clear dragged issue and hover state
+    setDraggedIssue(null);
+    setHoverState({ canDrop: true, columnId: '' });
     isDraggingRef.current = false;
-  }, [localIssues, columns, updateIssueMutation, onColumnUpdate, toast, view.id, queryClient, workspace.id]);
+  }, [localIssues, columns, updateIssueMutation, onColumnUpdate, view.id, hoverState, draggedIssue, toast]);
 
   // Issue handlers
   const handleIssueClick = useCallback((issueIdOrKey: string) => {
@@ -286,9 +361,12 @@ export const useKanbanState = ({
     displayProperties,
     showSubIssues,
     isLoadingStatuses,
+    draggedIssue,
+    hoverState,
     
     // Handlers
     handleDragStart,
+    handleDragUpdate,
     handleDragEnd,
     handleIssueClick,
     handleCreateIssue,

--- a/src/components/views/renderers/KanbanViewRenderer/index.tsx
+++ b/src/components/views/renderers/KanbanViewRenderer/index.tsx
@@ -35,9 +35,12 @@ export default function KanbanViewRenderer(props: KanbanViewRendererProps & {
     issueCounts,
     displayProperties,
     isLoadingStatuses,
+    draggedIssue,
+    hoverState,
     
     // Handlers
     handleDragStart,
+    handleDragUpdate,
     handleDragEnd,
     handleIssueClick,
     handleCreateIssue,
@@ -73,8 +76,11 @@ export default function KanbanViewRenderer(props: KanbanViewRendererProps & {
             projects={view.projects || []}
             workspaceId={workspaceId || workspace?.id || ''}
             currentUserId={currentUserId || ''}
+            draggedIssue={draggedIssue}
+            hoverState={hoverState}
             onDragEnd={handleDragEnd}
             onDragStart={handleDragStart}
+            onDragUpdate={handleDragUpdate}
             onIssueClick={handleIssueClick}
             onCreateIssue={handleCreateIssue}
             onStartCreatingIssue={handleStartCreatingIssue}

--- a/src/components/views/renderers/KanbanViewRenderer/types.ts
+++ b/src/components/views/renderers/KanbanViewRenderer/types.ts
@@ -55,6 +55,8 @@ export interface KanbanColumnProps {
   }>;
   workspaceId: string;
   currentUserId: string;
+  draggedIssue?: any;
+  hoverState: { canDrop: boolean, columnId: string };
   onIssueClick: (issueId: string) => void;
   onCreateIssue: (columnId: string) => void;
   onStartCreatingIssue: (columnId: string) => void;
@@ -96,8 +98,11 @@ export interface KanbanBoardProps {
   }>;
   workspaceId: string;
   currentUserId: string;
+  draggedIssue?: any;
+  hoverState: { canDrop: boolean, columnId: string };
   onDragEnd: (result: any) => void;
-  onDragStart: () => void;
+  onDragStart: (start: any) => void;
+  onDragUpdate: (update: any) => void;
   onIssueClick: (issueId: string) => void;
   onCreateIssue: (columnId: string) => void;
   onStartCreatingIssue: (columnId: string) => void;


### PR DESCRIPTION
## 📝 Summary

This pull request introduces enhanced drag-and-drop validation and improved visual feedback for the Kanban board, ensuring users cannot move issues to invalid columns and receive clear UI cues when a drop is not allowed. The changes span the Kanban board, column components, hooks, and types, and are grouped below by theme.

**Drag-and-drop validation and state management:**

* Added a `canIssueMoveTo` helper in `useKanbanState.ts` to validate whether an issue can be moved to a target column, considering project-specific statuses. Drag attempts to invalid columns are now blocked and users receive a toast notification.
* Introduced `draggedIssue` and `hoverState` state variables to track the currently dragged issue and whether a drop is allowed, passing these through the Kanban view, board, and column components. [[1]](diffhunk://#diff-54fe04ceafc821cb1d74d6c8c45d8ab7ef66a44eb00196bf09ced3135b0d418aR38-R39) [[2]](diffhunk://#diff-54fe04ceafc821cb1d74d6c8c45d8ab7ef66a44eb00196bf09ced3135b0d418aR364-R369) [[3]](diffhunk://#diff-0bb6df4fe639be6786616222cd8c42d52aed6a95ffba6615b353ae9877868ee2R38-R43) [[4]](diffhunk://#diff-0bb6df4fe639be6786616222cd8c42d52aed6a95ffba6615b353ae9877868ee2R79-R83) [[5]](diffhunk://#diff-97cdb73ea9820d271a848aca2663836a478a97081ffbde263f4073ffdea49755R20-R24) [[6]](diffhunk://#diff-97cdb73ea9820d271a848aca2663836a478a97081ffbde263f4073ffdea49755R73-R74) [[7]](diffhunk://#diff-71c8a6b374219d8beda5fd99dfc94e58b7ac1a3e066f4a7fbd1fcbd79d9f6183R32-R33) [[8]](diffhunk://#diff-a8df98585072b58dbf0e56179e6c63a17f1497468562e22ee4d10ba0d09fe132R58-R59) [[9]](diffhunk://#diff-a8df98585072b58dbf0e56179e6c63a17f1497468562e22ee4d10ba0d09fe132R101-R105)

**UI feedback and styling:**

* Updated `KanbanColumn.tsx` to show a disabled state and an error icon (`AlertCircle`) when hovering over a column where dropping is not allowed, including a reason tooltip and red border styling for clear feedback. [[1]](diffhunk://#diff-71c8a6b374219d8beda5fd99dfc94e58b7ac1a3e066f4a7fbd1fcbd79d9f6183R47-R50) [[2]](diffhunk://#diff-71c8a6b374219d8beda5fd99dfc94e58b7ac1a3e066f4a7fbd1fcbd79d9f6183R107-R111) [[3]](diffhunk://#diff-71c8a6b374219d8beda5fd99dfc94e58b7ac1a3e066f4a7fbd1fcbd79d9f6183L120-R144)
* Modified the empty column UI to disable pointer events during drag-over and only show the hover border when a drop is allowed.

**Component and prop updates:**

* Extended types for `KanbanBoardProps` and `KanbanColumnProps` to include new drag state props, and updated drag event handlers to support `onDragUpdate`. [[1]](diffhunk://#diff-a8df98585072b58dbf0e56179e6c63a17f1497468562e22ee4d10ba0d09fe132R58-R59) [[2]](diffhunk://#diff-a8df98585072b58dbf0e56179e6c63a17f1497468562e22ee4d10ba0d09fe132R101-R105) [[3]](diffhunk://#diff-97cdb73ea9820d271a848aca2663836a478a97081ffbde263f4073ffdea49755L48-R51)
* Updated imports in `KanbanColumn.tsx` to include the `AlertCircle` icon for error feedback.

## 🔗 Related Issue(s)

[CLB-B4](https://teams.weezboo.com/368c2c60-7be4-49b3-b269-eee3fca60684/issues/CLB-B4)

## ✅ Test Plan

<!-- How did you test the changes? Manual/automated? -->
- [ ] Unit tests added/updated
- [ ] Application tested locally
- [ ] E2E tests run (if applicable)

## 📸 Screenshots / Demo (if applicable)


https://github.com/user-attachments/assets/05f3bc53-4f7e-440c-83f5-30551dc5cb8e



## 📋 Checklist

- [ ] Code follows the project's coding standards
- [ ] Tests pass successfully
- [ ] Documentation (README, comments) updated if needed
- [ ] I have reviewed and signed the Code of Conduct and Contribution Guidelines
