### PR TITLE
Fix unassigning issues from assignee dropdown by sending null to API

### DIFF
--- a/src/components/issue/selectors/IssueAssigneeSelector.tsx
+++ b/src/components/issue/selectors/IssueAssigneeSelector.tsx
@@ -164,7 +164,7 @@ export function IssueAssigneeSelector({
           <button
             type="button"
             className="w-full flex items-center gap-2 px-2 py-1.5 text-xs rounded hover:bg-[#2a2a2a] transition-colors text-left"
-            onClick={() => onChange(undefined as any)}
+            onClick={() => onChange(null as any)}
           >
             <div className="h-5 w-5 rounded-full border-2 border-dashed border-[#555] flex items-center justify-center">
               <UserX className="h-2.5 w-2.5 text-[#6e7681]" />


### PR DESCRIPTION
## 📝 Summary

Clicking “No assignee” in IssueAssigneeSelector didn’t clear the assignee. The component emitted undefined, which the update API interprets as “do not change.” It now emits null, which correctly clears assigneeId.

## 🔗 Related Issue(s)

[https://teams.weezboo.com/368c2c60-7be4-49b3-b269-eee3fca60684/issues/CLB-B8](https://teams.weezboo.com/368c2c60-7be4-49b3-b269-eee3fca60684/issues/CLB-B8
)
## ✅ Test Plan

<!-- How did you test the changes? Manual/automated? -->
- [ ] Unit tests added/updated
- [ ] Application tested locally
- [ ] E2E tests run (if applicable)

## 📸 Screenshots / Demo (if applicable)

https://github.com/user-attachments/assets/ea8e6951-d115-44a1-9a8f-312d73e4c0a9

## 📋 Checklist

- [ ] Code follows the project's coding standards
- [ ] Tests pass successfully
- [ ] Documentation (README, comments) updated if needed
- [ ] I have reviewed and signed the Code of Conduct and Contribution Guidelines
