### PR TITLE
 Refactor Projects Page to show correct projects belongs to current Workspace

### DIFF
--- a/src/app/(main)/[workspaceId]/projects/ProjectsPageClient.tsx
+++ b/src/app/(main)/[workspaceId]/projects/ProjectsPageClient.tsx
@@ -26,11 +26,7 @@ import { cn } from '@/lib/utils';
 import PageHeader, { pageHeaderButtonStyles, pageHeaderSearchStyles } from '@/components/layout/PageHeader';
 import { format } from 'date-fns';
 
-interface ProjectsPageClientProps {
-  workspaceId: string;
-}
-
-export default function ProjectsPageClient({ workspaceId }: ProjectsPageClientProps) {
+export default function ProjectsPageClient() {
   const router = useRouter();
   const { currentWorkspace } = useWorkspace();
   const [searchQuery, setSearchQuery] = useState('');
@@ -38,12 +34,12 @@ export default function ProjectsPageClient({ workspaceId }: ProjectsPageClientPr
   const [showCreateModal, setShowCreateModal] = useState(false);
 
   const { data: projects = [], isLoading } = useProjects({
-    workspaceId,
+    workspaceId: currentWorkspace?.id,
     includeStats: true
   });
 
   const { data: views = [] } = useViews({
-    workspaceId,
+    workspaceId: currentWorkspace?.id,
     includeStats: true,
   });
 
@@ -466,10 +462,9 @@ export default function ProjectsPageClient({ workspaceId }: ProjectsPageClientPr
         <CreateProjectModal
           isOpen={showCreateModal}
           onClose={() => setShowCreateModal(false)}
-          workspaceId={workspaceId}
+          workspaceId={currentWorkspace?.id || ""}
           onProjectCreated={(project) => {
             console.log("Project created:", project);
-            // The useCreateProject hook will automatically invalidate queries
           }}
         />
       )}

--- a/src/app/(main)/[workspaceId]/projects/page.tsx
+++ b/src/app/(main)/[workspaceId]/projects/page.tsx
@@ -1,7 +1,6 @@
 import { Suspense } from 'react';
 import { redirect } from 'next/navigation';
 import { getAuthSession } from '@/lib/auth';
-import { verifyWorkspaceAccess } from '@/lib/workspace-helpers';
 import ProjectsPageClient from './ProjectsPageClient';
 
 interface Props {
@@ -15,17 +14,13 @@ export default async function ProjectsPage({ params }: Props) {
     redirect('/login');
   }
 
-  // Verify workspace access
-  const workspaceId = await verifyWorkspaceAccess(session.user);
-  const { workspaceId: paramWorkspaceId } = await params;
-
   return (
     <Suspense fallback={
       <div className="flex items-center justify-center h-64">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900"></div>
       </div>
     }>
-      <ProjectsPageClient workspaceId={workspaceId} />
+      <ProjectsPageClient/>
     </Suspense>
   );
 } 


### PR DESCRIPTION

## 📝 Summary

Refactor ProjectsPage and ProjectsPageClient components to remove workspaceId prop. Updated data fetching to use currentWorkspace context directly.

## 🔗 Related Issue(s)

[https://teams.weezboo.com/368c2c60-7be4-49b3-b269-eee3fca60684/issues/CLB-B23](https://teams.weezboo.com/368c2c60-7be4-49b3-b269-eee3fca60684/issues/CLB-B23
)
## ✅ Test Plan

<!-- How did you test the changes? Manual/automated? -->
- [ ] Unit tests added/updated
- [ ] Application tested locally
- [ ] E2E tests run (if applicable)

## 📸 Screenshots / Demo (if applicable)

<!-- Add screenshots or demo recordings for UI changes. -->
- 

## 📋 Checklist

- [ ] Code follows the project's coding standards
- [ ] Tests pass successfully
- [ ] Documentation (README, comments) updated if needed
- [ ] I have reviewed and signed the Code of Conduct and Contribution Guidelines
