### PR TITLE
Issue status selector fixed

### DIFF
--- a/src/components/RichEditor/components/IssueMentionSuggestion.tsx
+++ b/src/components/RichEditor/components/IssueMentionSuggestion.tsx
@@ -210,7 +210,7 @@ export function IssueMentionSuggestion({
           >
             {/* Status Icon */}
             <div className="flex items-center w-5 mr-1 flex-shrink-0">
-              {getStatusIcon(issue.status || 'todo')}
+              {getStatusIcon(issue.projectStatus?.displayName || issue.statusValue || issue.status || 'todo')}
             </div>
 
             {/* Issue Key */}

--- a/src/components/issue/IssueDetailContent.tsx
+++ b/src/components/issue/IssueDetailContent.tsx
@@ -870,6 +870,7 @@ export function IssueDetailContent({
                 value={issue.status}
                 onChange={(value) => handleUpdate({ status: value })}
                 projectId={issue.projectId}
+                currentStatus={issue.projectStatus}
                 disabled={isUpdating}
               />
 

--- a/src/components/ui/issue-mention-suggestion.tsx
+++ b/src/components/ui/issue-mention-suggestion.tsx
@@ -258,9 +258,9 @@ export const IssueMentionSuggestion = forwardRef<HTMLDivElement, IssueMentionSug
                             <Badge className={cn("text-xs", getTypeColor(issue.type))}>
                               {issue.type.toLowerCase()}
                             </Badge>
-                            {issue.status && (
-                              <Badge className={cn("text-xs", getStatusColor(issue.status))}>
-                                {issue.status}
+                            {(issue.projectStatus?.displayName || issue.statusValue || issue.status) && (
+                              <Badge className={cn("text-xs", getStatusColor(issue.projectStatus?.displayName || issue.statusValue || issue.status || 'Todo'))}>
+                                {issue.projectStatus?.displayName || issue.statusValue || issue.status}
                               </Badge>
                             )}
                             <Badge className={cn("text-xs", getPriorityColor(issue.priority))}>

--- a/src/components/views/ViewRenderer.tsx
+++ b/src/components/views/ViewRenderer.tsx
@@ -392,17 +392,21 @@ export default function ViewRenderer({
     switch (issueFilterType) {
       case 'active':
         filtered = filtered.filter(issue => {
-          const status = (issue.statusValue || issue.status || '').toLowerCase();
-          return status !== 'done' && 
-                 status !== 'backlog' && 
-                 status !== 'cancelled' &&
-                 status !== 'todo'; // Todo items should be in backlog, not active
+          // Use projectStatus if available, otherwise fallback to legacy fields
+          const status = issue.projectStatus?.name || issue.statusValue || issue.status || '';
+          const statusLower = status.toLowerCase();
+          return statusLower !== 'done' && 
+                 statusLower !== 'backlog' && 
+                 statusLower !== 'cancelled' &&
+                 statusLower !== 'todo'; // Todo items should be in backlog, not active
         });
         break;
       case 'backlog':
         filtered = filtered.filter(issue => {
-          const status = (issue.statusValue || issue.status || '').toLowerCase();
-          return status === 'backlog' || status === 'todo';
+          // Use projectStatus if available, otherwise fallback to legacy fields
+          const status = issue.projectStatus?.name || issue.statusValue || issue.status || '';
+          const statusLower = status.toLowerCase();
+          return statusLower === 'backlog' || statusLower === 'todo';
         });
         break;
       default:
@@ -781,12 +785,16 @@ export default function ViewRenderer({
     // Now compute counts per tab from the filtered dataset
     const allIssuesCount = countingIssues.length;
     const activeIssuesCount = countingIssues.filter((issue: any) => {
-      const status = (issue.statusValue || issue.status || '').toLowerCase();
-      return status !== 'done' && status !== 'backlog' && status !== 'cancelled' && status !== 'todo';
+      // Use projectStatus if available, otherwise fallback to legacy fields
+      const status = issue.projectStatus?.name || issue.statusValue || issue.status || '';
+      const statusLower = status.toLowerCase();
+      return statusLower !== 'done' && statusLower !== 'backlog' && statusLower !== 'cancelled' && statusLower !== 'todo';
     }).length;
     const backlogIssuesCount = countingIssues.filter((issue: any) => {
-      const status = (issue.statusValue || issue.status || '').toLowerCase();
-      return status === 'backlog' || status === 'todo';
+      // Use projectStatus if available, otherwise fallback to legacy fields  
+      const status = issue.projectStatus?.name || issue.statusValue || issue.status || '';
+      const statusLower = status.toLowerCase();
+      return statusLower === 'backlog' || statusLower === 'todo';
     }).length;
 
     return { allIssuesCount, activeIssuesCount, backlogIssuesCount };

--- a/src/components/views/renderers/KanbanViewRenderer/hooks/useKanbanState.ts
+++ b/src/components/views/renderers/KanbanViewRenderer/hooks/useKanbanState.ts
@@ -89,7 +89,9 @@ export const useKanbanState = ({
   // Helper function to validate if an issue can be moved to a target column
   const canIssueMoveTo = useCallback((issue: any, targetColumnId: string): boolean => {
     // Allow movement within the same column (reordering)
-    if (issue.status === targetColumnId || issue.statusValue === targetColumnId) {
+    if (issue.projectStatus?.name === targetColumnId || 
+        issue.statusValue === targetColumnId || 
+        issue.status === targetColumnId) {
       return true;
     }
 

--- a/src/components/views/renderers/KanbanViewRenderer/utils.ts
+++ b/src/components/views/renderers/KanbanViewRenderer/utils.ts
@@ -185,7 +185,7 @@ export const createColumns = (filteredIssues: any[], view: any, projectStatuses?
         groupKey = groupValue.toLowerCase();
         break;
       default:
-        groupValue = issue.statusValue || issue.status || 'todo';
+        groupValue = issue.projectStatus?.displayName || issue.statusValue || issue.status || 'todo';
         groupKey = groupValue;
     }
     
@@ -233,15 +233,19 @@ export const createColumns = (filteredIssues: any[], view: any, projectStatuses?
 
 export const countIssuesByType = (issues: any[]) => {
   const allIssuesCount = issues.length;
-  const activeIssuesCount = issues.filter(issue => 
-    issue.status !== 'Done' && 
-    issue.status !== 'Backlog' && 
-    issue.status !== 'Cancelled'
-  ).length;
-  const backlogIssuesCount = issues.filter(issue => 
-    issue.status === 'Backlog' || 
-    issue.status === 'Todo'
-  ).length;
+  const activeIssuesCount = issues.filter(issue => {
+    const status = issue.projectStatus?.name || issue.statusValue || issue.status || '';
+    const statusLower = status.toLowerCase();
+    return statusLower !== 'done' && 
+           statusLower !== 'backlog' && 
+           statusLower !== 'cancelled';
+  }).length;
+  const backlogIssuesCount = issues.filter(issue => {
+    const status = issue.projectStatus?.name || issue.statusValue || issue.status || '';
+    const statusLower = status.toLowerCase();
+    return statusLower === 'backlog' || 
+           statusLower === 'todo';
+  }).length;
 
   return {
     allIssuesCount,

--- a/src/components/views/renderers/ListViewRenderer.tsx
+++ b/src/components/views/renderers/ListViewRenderer.tsx
@@ -198,8 +198,14 @@ export default function ListViewRenderer({
       
       switch (displaySettings.grouping) {
         case 'status':
-          groupKey = normalizeStatus(issue.status || 'Todo');
-          groupName = groupKey;
+          // Use projectStatus if available, otherwise fallback to legacy fields
+          if (issue.projectStatus?.name) {
+            groupKey = issue.projectStatus.name;
+            groupName = issue.projectStatus.displayName || issue.projectStatus.name;
+          } else {
+            groupKey = normalizeStatus(issue.statusValue || issue.status || 'Todo');
+            groupName = groupKey;
+          }
           break;
         case 'priority':
           groupKey = issue.priority || 'MEDIUM';

--- a/src/components/views/renderers/TableViewRenderer.tsx
+++ b/src/components/views/renderers/TableViewRenderer.tsx
@@ -239,10 +239,10 @@ export default function TableViewRenderer({
                       variant="outline" 
                       className={cn(
                         "text-xs border-current/20 bg-current/5",
-                        getStatusColor(issue.status)
+                        getStatusColor(issue.projectStatus?.displayName || issue.statusValue || issue.status || 'Todo')
                       )}
                     >
-                      {issue.status || 'Todo'}
+                      {issue.projectStatus?.displayName || issue.statusValue || issue.status || 'Todo'}
                     </Badge>
                   </div>
 

--- a/src/types/issue.ts
+++ b/src/types/issue.ts
@@ -89,6 +89,17 @@ export interface Issue {
   columnId?: string;
   column?: IssueColumn;
   
+  // Status system
+  statusId?: string;
+  projectStatus?: {
+    id: string;
+    name: string;
+    displayName: string;
+    color?: string;
+    iconName?: string;
+    order: number;
+  } | null;
+  
   // Dates
   dueDate?: Date;
   startDate?: Date;


### PR DESCRIPTION
## 📝 Summary

This pull request improves how issue status is handled and displayed throughout the application by introducing consistent usage of the new `projectStatus` object and enhancing compatibility with legacy fields. The changes ensure that status information is more robustly matched, displayed, and filtered, reducing inconsistencies and edge cases when working with issues across different components and views.

**Status Handling and Matching Improvements**
- Enhanced status lookup in the API to match by multiple fields and normalize input (name, displayName, case, underscores, spaces), and now updates the canonical status name for both legacy and new fields. ([src/app/api/issues/[issueId]/route.tsR334-R360](diffhunk://#diff-e7973fe9e3191989b466965eee13a5a018e367fccac1dfe10dceb34e12eb2438R334-R360))
- The `Issue` type and related components now include a `projectStatus` object with fields like `id`, `name`, `displayName`, `color`, and `iconName`, supporting richer status representation. [[1]](diffhunk://#diff-974ec7f4a277cbb13773a04c437a6cbe79dc0348f13bd643ecfdc2683c6ab784R92-R102) [[2]](diffhunk://#diff-2053c996169891553cc687b6bb0e195ae9cbf07c5d4d3213425745608c519cb1R25-R33)

**UI Consistency and Display Updates**
- All status badges, selectors, and mentions now consistently display the `projectStatus.displayName` if available, falling back to `statusValue` or legacy `status`. This affects components such as `IssueStatusSelector`, `IssueMentionSuggestion`, and table/kanban/list views. [[1]](diffhunk://#diff-2053c996169891553cc687b6bb0e195ae9cbf07c5d4d3213425745608c519cb1R122-R173) [[2]](diffhunk://#diff-2053c996169891553cc687b6bb0e195ae9cbf07c5d4d3213425745608c519cb1L128-R186) [[3]](diffhunk://#diff-2053c996169891553cc687b6bb0e195ae9cbf07c5d4d3213425745608c519cb1L146-R206) [[4]](diffhunk://#diff-2053c996169891553cc687b6bb0e195ae9cbf07c5d4d3213425745608c519cb1L158-R216) [[5]](diffhunk://#diff-2053c996169891553cc687b6bb0e195ae9cbf07c5d4d3213425745608c519cb1L176-R241) [[6]](diffhunk://#diff-29582dc1ca921cdeb2662736abdeee4daa2e553e41b23a58c67bb10f681a3137L261-R263) [[7]](diffhunk://#diff-6adb68683b19d72ea4a0e31c8eaab4275e80788b77a56c0f334127b8b81d4717L242-R245) [[8]](diffhunk://#diff-4c31e68f36c3caa0133b4fb4f3443ed745b23274a0996d9132269560d51243deL213-R213)
- The `IssueStatusSelector` component now accepts and uses a `currentStatus` prop for more accurate display and selection. [[1]](diffhunk://#diff-5c6ec2fe3f22bbc36a66c135dc7bdeeeaeba54d8ef4e8155b6a1a03ebf04c949R873) [[2]](diffhunk://#diff-2053c996169891553cc687b6bb0e195ae9cbf07c5d4d3213425745608c519cb1R82)

**Filtering, Grouping, and Counting by Status**
- All filtering, grouping, and counting logic (in list, kanban, table, and view renderers) now prioritize `projectStatus.name` for status checks, ensuring correct behavior regardless of which status field is present. [[1]](diffhunk://#diff-846f9655dd60db7c0cec7a80bebb2678c691a0442820494cd75f7c913d116fdcL395-R409) [[2]](diffhunk://#diff-846f9655dd60db7c0cec7a80bebb2678c691a0442820494cd75f7c913d116fdcL784-R797) [[3]](diffhunk://#diff-54fe04ceafc821cb1d74d6c8c45d8ab7ef66a44eb00196bf09ced3135b0d418aL92-R94) [[4]](diffhunk://#diff-2f6e3e7001eb52cc60273ef01057ae5dc3039355671a2bc71f57f74ffc0a6132L188-R188) [[5]](diffhunk://#diff-2f6e3e7001eb52cc60273ef01057ae5dc3039355671a2bc71f57f74ffc0a6132L236-R248) [[6]](diffhunk://#diff-9dfd748edfae425267a82a79cd143a64aaffaa0ab5d151f799cbdc0bde9f6ccbL201-R208)

These changes collectively make the status system more flexible, reliable, and visually consistent across the application.
- 

## 🔗 Related Issue(s)

<!-- Link any related issues. Example: Closes #123 -->
- 

## ✅ Test Plan

<!-- How did you test the changes? Manual/automated? -->
- [ ] Unit tests added/updated
- [ ] Application tested locally
- [ ] E2E tests run (if applicable)

## 📸 Screenshots / Demo (if applicable)

<!-- Add screenshots or demo recordings for UI changes. -->
- 

## 📋 Checklist

- [ ] Code follows the project's coding standards
- [ ] Tests pass successfully
- [ ] Documentation (README, comments) updated if needed
- [ ] I have reviewed and signed the Code of Conduct and Contribution Guidelines
