### PR TITLE
Add relations for 'BLOCKED_BY' and 'DUPLICATED_BY' types in issue relations

### DIFF
--- a/src/app/api/workspaces/[workspaceId]/issues/[issueKey]/relations/route.ts
+++ b/src/app/api/workspaces/[workspaceId]/issues/[issueKey]/relations/route.ts
@@ -149,11 +149,17 @@ export async function GET(
         case 'BLOCKS':
           relations.blocks.push(relatedIssue);
           break;
+        case 'BLOCKED_BY':
+          relations.blocked_by.push(relatedIssue);
+          break;
         case 'RELATES_TO':
           relations.relates_to.push(relatedIssue);
           break;
         case 'DUPLICATES':
           relations.duplicates.push(relatedIssue);
+          break;
+        case 'DUPLICATED_BY':
+          relations.duplicated_by.push(relatedIssue);
           break;
         // Intentionally ignore 'CHILD' type going forward; parent/child is represented via 'PARENT'
       }
@@ -185,11 +191,17 @@ export async function GET(
         case 'BLOCKS':
           relations.blocked_by.push(relatedIssue);
           break;
+        case 'BLOCKED_BY':
+          relations.blocks.push(relatedIssue);
+          break;
         case 'RELATES_TO':
           relations.relates_to.push(relatedIssue);
           break;
         case 'DUPLICATES':
           relations.duplicated_by.push(relatedIssue);
+          break;
+        case 'DUPLICATED_BY':
+          relations.duplicates.push(relatedIssue);
           break;
         // Ignore legacy 'CHILD' entries
       }

--- a/src/components/issue/sections/relations/index.ts
+++ b/src/components/issue/sections/relations/index.ts
@@ -2,7 +2,6 @@
 export { IssueRelationsSection } from "./IssueRelationsSection";
 
 // Components
-export { RelationItem } from "./components/RelationItem";
 export { RelationGroup } from "./components/RelationGroup";
 export { AddRelationModal } from "./components/AddRelationModal";
 export { SearchRelationItem } from "./components/SearchRelationItem";


### PR DESCRIPTION
## 📝 Summary

This pull request improves the handling of issue relations in the API and cleans up exports in the relations section component. The main changes ensure that both forward and reverse relations (like "blocks" and "blocked by", "duplicates" and "duplicated by") are properly tracked and returned, increasing the accuracy and flexibility of issue relationship queries.

**API improvements for issue relations:**

* Added support for the reverse relation types `'BLOCKED_BY'` and `'DUPLICATED_BY'` in the `GET` endpoint for issue relations, ensuring both sides of these relationships are correctly populated in the response. (`src/app/api/workspaces/[workspaceId]/issues/[issueKey]/relations/route.ts`) ([src/app/api/workspaces/[workspaceId]/issues/[issueKey]/relations/route.tsR152-R163](diffhunk://#diff-091c5a92f210983e8b77c1b4b7ed60ee6d61dfd3e739f6cedb875ccefe3c0b76R152-R163), [src/app/api/workspaces/[workspaceId]/issues/[issueKey]/relations/route.tsR194-R205](diffhunk://#diff-091c5a92f210983e8b77c1b4b7ed60ee6d61dfd3e739f6cedb875ccefe3c0b76R194-R205))

**Component export cleanup:**

* Removed the unused export of `RelationItem` from the relations section index to streamline the public API. (`src/components/issue/sections/relations/index.ts`)

## 🔗 Related Issue(s)

[CLB-162](https://teams.weezboo.com/368c2c60-7be4-49b3-b269-eee3fca60684/issues/CLB-162)

## ✅ Test Plan

<!-- How did you test the changes? Manual/automated? -->
- [ ] Unit tests added/updated
- [ ] Application tested locally
- [ ] E2E tests run (if applicable)

## 📸 Screenshots / Demo (if applicable)

## 📋 Checklist

- [ ] Code follows the project's coding standards
- [ ] Tests pass successfully
- [ ] Documentation (README, comments) updated if needed
- [ ] I have reviewed and signed the Code of Conduct and Contribution Guidelines
