### PR TITLE
Issue search results ordered by descending createdAt value

### DIFF
--- a/src/app/api/issues/search/route.ts
+++ b/src/app/api/issues/search/route.ts
@@ -117,6 +117,7 @@ export async function GET(request: NextRequest) {
           }
         },
         include: includeClause,
+        orderBy: { createdAt: 'desc' },
         take: 10
       });
 
@@ -135,6 +136,7 @@ export async function GET(request: NextRequest) {
             })
           },
           include: includeClause,
+          orderBy: { createdAt: 'desc' },
           take: 10 - exactIssueKeyMatches.length
         });
       }
@@ -156,6 +158,7 @@ export async function GET(request: NextRequest) {
             })
           },
           include: includeClause,
+          orderBy: { createdAt: 'desc' },
           take: 10 - currentCount
         });
       }
@@ -177,6 +180,7 @@ export async function GET(request: NextRequest) {
             })
           },
           include: includeClause,
+          orderBy: { createdAt: 'desc' },
           take: 10 - finalCount
         });
       }
@@ -235,6 +239,10 @@ export async function GET(request: NextRequest) {
       project: issue.project,
       workspace: issue.workspace,
       assignee: issue.assignee,
+      createdAt: issue.createdAt,
+      updatedAt: issue.updatedAt,
+      dueDate: issue.dueDate,
+      _count: issue._count
     }));
 
     return NextResponse.json(transformedIssues, { status: 200 });

--- a/src/components/issue/sections/relations/components/SearchRelationItem.tsx
+++ b/src/components/issue/sections/relations/components/SearchRelationItem.tsx
@@ -144,7 +144,7 @@ export function SearchRelationItem({
       </div>
 
       {/* Updated Date */}
-      <div className="flex-shrink-0 w-10">
+      <div className="flex-shrink-0 w-12">
         <span className="text-[#6e7681] text-xs">
           {format(new Date(item.updatedAt), 'MMM d')}
         </span>

--- a/src/components/issue/sections/relations/hooks/useRelationSearch.ts
+++ b/src/components/issue/sections/relations/hooks/useRelationSearch.ts
@@ -41,7 +41,7 @@ export function useRelationSearch(
               apiType = 'BUG';
               break;
             default:
-              apiType = type.toUpperCase();
+              apiType = String(type).toUpperCase();
           }
           searchParams.append("type", apiType);
         });


### PR DESCRIPTION
## 📝 Summary
This pull request improves the issue search API and related UI by enhancing result ordering, expanding returned data fields, and making minor UI and type handling adjustments. The main focus is on ensuring search results are consistently ordered by creation date and that more comprehensive issue data is available to the frontend.

**Backend: Issue Search Enhancements**
- Added ordering by `createdAt` (descending) to all relevant Prisma queries in the issue search API to ensure the newest issues appear first in search results. [[1]](diffhunk://#diff-c590821e0125556b6ed68bcd9c2b6029026b142a89fa84a201f2e607bf6a03daR120) [[2]](diffhunk://#diff-c590821e0125556b6ed68bcd9c2b6029026b142a89fa84a201f2e607bf6a03daR139) [[3]](diffhunk://#diff-c590821e0125556b6ed68bcd9c2b6029026b142a89fa84a201f2e607bf6a03daR161) [[4]](diffhunk://#diff-c590821e0125556b6ed68bcd9c2b6029026b142a89fa84a201f2e607bf6a03daR183)
- Expanded the returned issue data to include `createdAt`, `updatedAt`, `dueDate`, and `_count` fields, making more metadata available to the frontend.

**Frontend/UI Adjustments**
- Increased the width of the updated date column in the `SearchRelationItem` component for better display of date information.

**Type Handling**
- Ensured that the `type` parameter is always converted to a string before calling `toUpperCase()` in the `useRelationSearch` hook, improving type safety and preventing potential runtime errors.
- 

## 🔗 Related Issue(s)

<!-- Link any related issues. Example: Closes #123 -->
- 

## ✅ Test Plan

<!-- How did you test the changes? Manual/automated? -->
- [ ] Unit tests added/updated
- [ ] Application tested locally
- [ ] E2E tests run (if applicable)

## 📸 Screenshots / Demo (if applicable)

<!-- Add screenshots or demo recordings for UI changes. -->
- 

## 📋 Checklist

- [ ] Code follows the project's coding standards
- [ ] Tests pass successfully
- [ ] Documentation (README, comments) updated if needed
- [ ] I have reviewed and signed the Code of Conduct and Contribution Guidelines
