### PR TITLE
Remove Timesheet and Messages links from sidebar

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -23,7 +23,6 @@ import {
   Bookmark,
   Tag,
   Lightbulb,
-  Timer,
   Bell,
   Search as SearchIcon,
   Calendar,
@@ -289,12 +288,6 @@ export default function Sidebar({
       current: pathname.includes("/timeline"),
     },
     {
-      name: "Timesheet",
-      href: currentWorkspace ? `/${currentWorkspace.slug || currentWorkspace.id}/timesheet` : "#",
-      icon: Timer,
-      current: pathname.includes("/timesheet"),
-    },
-    {
       name: "Notes",
       href: currentWorkspace ? `/${currentWorkspace.slug || currentWorkspace.id}/notes` : "#",
       icon: FileText,
@@ -305,12 +298,6 @@ export default function Sidebar({
       href: currentWorkspace ? `/${currentWorkspace.slug || currentWorkspace.id}/bookmarks` : "#",
       icon: Bookmark,
       current: pathname.includes("/bookmarks"),
-    },
-    {
-      name: "Messages",
-      href: currentWorkspace ? `/${currentWorkspace.slug || currentWorkspace.id}/messages` : "#",
-      icon: MessageSquare,
-      current: pathname.includes("/messages"),
     },
     {
       name: "Tags",


### PR DESCRIPTION
## Summary
- remove Timesheet and Messages routes from the sidebar workspace feature list so they no longer render
- drop the unused Timer icon import from the sidebar component

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68cbff771cbc8321991fe540fecd2dc1