### PR TITLE
Sync development branch changes to uat

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -23,7 +23,6 @@ import {
   Bookmark,
   Tag,
   Lightbulb,
-  Timer,
   Bell,
   Search as SearchIcon,
   Calendar,
@@ -289,12 +288,6 @@ export default function Sidebar({
       current: pathname.includes("/timeline"),
     },
     {
-      name: "Timesheet",
-      href: currentWorkspace ? `/${currentWorkspace.slug || currentWorkspace.id}/timesheet` : "#",
-      icon: Timer,
-      current: pathname.includes("/timesheet"),
-    },
-    {
       name: "Notes",
       href: currentWorkspace ? `/${currentWorkspace.slug || currentWorkspace.id}/notes` : "#",
       icon: FileText,
@@ -305,12 +298,6 @@ export default function Sidebar({
       href: currentWorkspace ? `/${currentWorkspace.slug || currentWorkspace.id}/bookmarks` : "#",
       icon: Bookmark,
       current: pathname.includes("/bookmarks"),
-    },
-    {
-      name: "Messages",
-      href: currentWorkspace ? `/${currentWorkspace.slug || currentWorkspace.id}/messages` : "#",
-      icon: MessageSquare,
-      current: pathname.includes("/messages"),
     },
     {
       name: "Tags",


### PR DESCRIPTION
This pull request simplifies the `Sidebar` component by removing unused or unnecessary navigation items and their associated icons. The main focus is on streamlining the sidebar navigation for a cleaner user interface.

Navigation cleanup:

* Removed the "Timesheet" navigation item and its associated `Timer` icon from the sidebar. [[1]](diffhunk://#diff-6d581b4911012761e0ce28d8df437c4f41fe956b8fc6a176529a40964d11f4d9L26) [[2]](diffhunk://#diff-6d581b4911012761e0ce28d8df437c4f41fe956b8fc6a176529a40964d11f4d9L291-L296)
* Removed the "Messages" navigation item and its associated `MessageSquare` icon from the sidebar.