### PR TITLE
Prevent RichEditor stucks on tag

### DIFF
--- a/src/components/RichEditor/RichEditor.tsx
+++ b/src/components/RichEditor/RichEditor.tsx
@@ -79,6 +79,14 @@ export const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(({
   // Guard to suppress transient checks during mention insertion
   const isInsertingMentionRef = useRef(false);
   
+  // Helper to release guards on the next tick after ProseMirror updates
+  const releaseMentionGuardsNextTick = () => {
+    setTimeout(() => {
+      isInsertingMentionRef.current = false;
+      isExternalUpdateRef.current = false;
+    }, 0);
+  };
+  
   // State for floating toolbar and mentions
   const [showFloatingMenu, setShowFloatingMenu] = useState(false);
   const [floatingMenuPosition, setFloatingMenuPosition] = useState({ top: 0, left: 0 });
@@ -367,10 +375,7 @@ export const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(({
         trigger.char
       );
       // Release guards on next tick after ProseMirror updates
-      setTimeout(() => {
-        isInsertingMentionRef.current = false;
-        isExternalUpdateRef.current = false;
-      }, 0);
+      releaseMentionGuardsNextTick();
     }
     
     setMentionSuggestion(null);
@@ -403,10 +408,7 @@ export const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(({
         trigger.char
       );
       // Release guards on next tick after ProseMirror updates
-      setTimeout(() => {
-        isInsertingMentionRef.current = false;
-        isExternalUpdateRef.current = false;
-      }, 0);
+      releaseMentionGuardsNextTick();
     }
     
     setMentionSuggestion(null);

--- a/src/components/RichEditor/RichEditor.tsx
+++ b/src/components/RichEditor/RichEditor.tsx
@@ -778,7 +778,6 @@ export const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(({
         )} 
         ref={editorRef}
         onClick={() => editor?.commands.focus()}
-        // Key handling is managed via editorProps.handleKeyDown to avoid duplicate invocation
         style={{ 
           minHeight: toolbarMode === 'static' ? 'auto' : minHeight,
           maxHeight: maxHeight && maxHeight !== 'none' ? maxHeight : undefined

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -23,7 +23,6 @@ import {
   Bookmark,
   Tag,
   Lightbulb,
-  Timer,
   Bell,
   Search as SearchIcon,
   Calendar,
@@ -289,12 +288,6 @@ export default function Sidebar({
       current: pathname.includes("/timeline"),
     },
     {
-      name: "Timesheet",
-      href: currentWorkspace ? `/${currentWorkspace.slug || currentWorkspace.id}/timesheet` : "#",
-      icon: Timer,
-      current: pathname.includes("/timesheet"),
-    },
-    {
       name: "Notes",
       href: currentWorkspace ? `/${currentWorkspace.slug || currentWorkspace.id}/notes` : "#",
       icon: FileText,
@@ -305,12 +298,6 @@ export default function Sidebar({
       href: currentWorkspace ? `/${currentWorkspace.slug || currentWorkspace.id}/bookmarks` : "#",
       icon: Bookmark,
       current: pathname.includes("/bookmarks"),
-    },
-    {
-      name: "Messages",
-      href: currentWorkspace ? `/${currentWorkspace.slug || currentWorkspace.id}/messages` : "#",
-      icon: MessageSquare,
-      current: pathname.includes("/messages"),
     },
     {
       name: "Tags",

--- a/src/components/ui/collab-text.tsx
+++ b/src/components/ui/collab-text.tsx
@@ -1,6 +1,9 @@
 "use client"
 
 import { cn } from "@/lib/utils"
+import { useRouter } from "next/navigation"
+import { useWorkspace } from "@/context/WorkspaceContext"
+import type React from "react"
 
 interface CollabTextProps {
   content: string
@@ -19,10 +22,11 @@ export function CollabText({
   withBackground = false,
   asSpan = false
 }: CollabTextProps) {
+  const router = useRouter()
+  const { currentWorkspace } = useWorkspace()
   // Parse and format the content with mentions
   const formatTextWithMentions = () => {
     if (!content) return { __html: "" }
-    
     // Escape HTML special characters to prevent XSS
     let formatted = content
       .replace(/&/g, "&amp;")
@@ -31,11 +35,11 @@ export function CollabText({
       .replace(/"/g, "&quot;")
       .replace(/'/g, "&#039;")
     
-    // Convert @[username](userId) to clickable links
+    // Convert @[username](userId) to clickable spans (routing handled via onClick)
     formatted = formatted.replace(
       /@\[([^\]]+)\]\(([^)]+)\)/g,
       (_, name, id) => {
-        return `<a href="/profile/${id}" class="mention mention-link" data-user-id="${id}"><span class="mention-symbol">@</span>${name}</a>`
+        return `<span class="mention mention-link" data-user-id="${id}"><span class="mention-symbol">@</span>${name}</span>`
       }
     )
     
@@ -59,6 +63,29 @@ export function CollabText({
     return { __html: formatted }
   }
   
+  const handleClick = (event: React.MouseEvent<HTMLDivElement | HTMLSpanElement>) => {
+    const target = event.target as HTMLElement
+    const userMention = target.closest('.mention-link[data-user-id]') as HTMLElement | null
+    const issueMention = target.closest('.mention-link[data-issue-id]') as HTMLElement | null
+    const workspaceSegment = currentWorkspace?.slug || currentWorkspace?.id
+    
+    if (userMention && workspaceSegment) {
+      const userId = userMention.getAttribute('data-user-id')
+      if (userId) {
+        event.preventDefault()
+        event.stopPropagation()
+        router.push(`/${workspaceSegment}/profile/${userId}`)
+      }
+    } else if (issueMention && workspaceSegment) {
+      const issueId = issueMention.getAttribute('data-issue-id')
+      if (issueId) {
+        event.preventDefault()
+        event.stopPropagation()
+        router.push(`/${workspaceSegment}/issues/${issueId}`)
+      }
+    }
+  }
+  
   const Container = asSpan ? 'span' : 'div';
   const ContentContainer = asSpan ? 'span' : 'div';
   
@@ -68,7 +95,7 @@ export function CollabText({
       small ? "text-sm" : "",
       withBackground ? "p-3 rounded-md bg-card/40 border border-border/30" : "",
       className
-    )}>
+    )} onClick={handleClick}>
       {title && <h3 className="font-medium mb-2">{title}</h3>}
       <ContentContainer dangerouslySetInnerHTML={formatTextWithMentions()} />
     </Container>

--- a/src/components/ui/markdown-content.tsx
+++ b/src/components/ui/markdown-content.tsx
@@ -53,10 +53,10 @@ export function MarkdownContent({ content, htmlContent, className, asSpan = fals
         '<span class="milestone-mention" data-id="$2"><span class="mention-symbol">!</span>$1</span>'
       );
       
-      // Issue mentions: #[key](id) -> clickable mention
+      // Issue mentions: #[key](id) -> clickable mention span (routing handled via onClick)
       processed = processed.replace(
         /#\[([^\]]+)\]\(([^)]+)\)/g,
-        `<a href="/${currentWorkspace?.slug}/issues/$2" class="mention mention-link" data-issue-id="$2"><span class="mention-symbol">#</span>$1</a>`
+        '<span class="mention mention-link" data-issue-id="$2"><span class="mention-symbol">#</span>$1</span>'
       );
       
       // Convert newlines to <br> tags if needed
@@ -194,48 +194,26 @@ export function MarkdownContent({ content, htmlContent, className, asSpan = fals
   // Click handler for event delegation
   const handleClick = (event: React.MouseEvent<HTMLDivElement | HTMLSpanElement>) => {
     const target = event.target as HTMLElement;
-    
+
     // Check for different types of mentions
-    const userMention = target.closest('.mention-link[data-user-id]');
-    const epicMention = target.closest('.epic-mention');
-    const storyMention = target.closest('.story-mention');
-    const milestoneMention = target.closest('.milestone-mention');
-    const issueMention = target.closest('.issue-mention');
-    
-    if (userMention) {
+    const userMention = target.closest('.mention-link[data-user-id]') as HTMLElement | null;
+    const issueMention = target.closest('.mention-link[data-issue-id]') as HTMLElement | null;
+
+    if (userMention && currentWorkspace) {
       const userId = userMention.getAttribute('data-user-id');
-      if (userId && currentWorkspace) {
+      if (userId) {
         event.preventDefault();
         event.stopPropagation();
-        router.push(`/${currentWorkspace.id}/profile/${userId}`);
+        const workspaceSegment = currentWorkspace.slug || currentWorkspace.id;
+        router.push(`/${workspaceSegment}/profile/${userId}`);
       }
-    } else if (epicMention) {
-      const epicId = epicMention.getAttribute('data-id');
-      if (epicId && currentWorkspace) {
-        event.preventDefault();
-        event.stopPropagation();
-        router.push(`/${currentWorkspace.id}/epics/${epicId}`);
-      }
-    } else if (storyMention) {
-      const storyId = storyMention.getAttribute('data-id');
-      if (storyId && currentWorkspace) {
-        event.preventDefault();
-        event.stopPropagation();
-        router.push(`/${currentWorkspace.id}/stories/${storyId}`);
-      }
-    } else if (milestoneMention) {
-      const milestoneId = milestoneMention.getAttribute('data-id');
-      if (milestoneId && currentWorkspace) {
-        event.preventDefault();
-        event.stopPropagation();
-        router.push(`/${currentWorkspace.id}/milestones/${milestoneId}`);
-      }
-    } else if (issueMention) {
+    } else if (issueMention && currentWorkspace) {
       const issueId = issueMention.getAttribute('data-issue-id');
-      if (issueId && currentWorkspace) {
+      if (issueId) {
         event.preventDefault();
         event.stopPropagation();
-        router.push(`/${currentWorkspace.id}/issues/${issueId}`);
+        const workspaceSegment = currentWorkspace.slug || currentWorkspace.id;
+        router.push(`/${workspaceSegment}/issues/${issueId}`);
       }
     }
   };


### PR DESCRIPTION
## 📝 Summary

Introduces guards to avoid recursive update loops when programmatically setting content or inserting mentions in RichEditor. Ensures onChange and mention trigger checks are only called when appropriate, improving editor stability and preventing unintended side effects.

## 🔗 Related Issue(s)

[CLB-193](https://teams.weezboo.com/368c2c60-7be4-49b3-b269-eee3fca60684/issues/CLB-193)
[CLB-197](https://teams.weezboo.com/368c2c60-7be4-49b3-b269-eee3fca60684/issues/CLB-197)

## ✅ Test Plan

<!-- How did you test the changes? Manual/automated? -->
- [ ] Unit tests added/updated
- [ ] Application tested locally
- [ ] E2E tests run (if applicable)

## 📸 Screenshots / Demo (if applicable)

<!-- Add screenshots or demo recordings for UI changes. -->
- 

## 📋 Checklist

- [ ] Code follows the project's coding standards
- [ ] Tests pass successfully
- [ ] Documentation (README, comments) updated if needed
- [ ] I have reviewed and signed the Code of Conduct and Contribution Guidelines
