### PR TITLE
ESC keypress closing issue feature removed

### DIFF
--- a/src/components/issue/IssueDetailContent.tsx
+++ b/src/components/issue/IssueDetailContent.tsx
@@ -692,8 +692,6 @@ export function IssueDetailContent({
         if (editingTitle) {
           setEditingTitle(false);
           setTitle(issue?.title || '');
-        } else {
-          onClose?.();
         }
       }
     };


### PR DESCRIPTION
## 📝 Summary

This pull request makes a minor adjustment to the behavior of the `IssueDetailContent` component. Specifically, it removes the call to `onClose` when the user is not editing the title, likely to prevent unintended closing of the issue detail view.

- Removed the invocation of `onClose` in the cancel handler when not editing the issue title in `IssueDetailContent.tsx`
- 

## 🔗 Related Issue(s)

<!-- Link any related issues. Example: Closes #123 -->
- 

## ✅ Test Plan

<!-- How did you test the changes? Manual/automated? -->
- [ ] Unit tests added/updated
- [ ] Application tested locally
- [ ] E2E tests run (if applicable)

## 📸 Screenshots / Demo (if applicable)

<!-- Add screenshots or demo recordings for UI changes. -->
- 

## 📋 Checklist

- [ ] Code follows the project's coding standards
- [ ] Tests pass successfully
- [ ] Documentation (README, comments) updated if needed
- [ ] I have reviewed and signed the Code of Conduct and Contribution Guidelines
