### PR TITLE
Sidebar toggle button fixed on Workspace layouts

### DIFF
--- a/src/app/(main)/create-workspace/layout.tsx
+++ b/src/app/(main)/create-workspace/layout.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { redirect } from "next/navigation";
 import { getAuthSession } from "@/lib/auth";
 import LayoutWithSidebar from "@/components/layout/LayoutWithSidebar";
+import SidebarProvider from "@/components/providers/SidebarProvider";
 
 export default async function CreateWorkspaceLayout({
   children,
@@ -17,10 +18,10 @@ export default async function CreateWorkspaceLayout({
 
   const pathname = "/create-workspace";
   return (
-    <>
-      <LayoutWithSidebar session={session} pathname={pathname}>
+    <SidebarProvider>
+      <LayoutWithSidebar pathname={pathname}>
         <div className="mx-auto w-full h-full">{children}</div>
       </LayoutWithSidebar>
-    </>
+    </SidebarProvider>
   );
 } 

--- a/src/app/(main)/workspaces/layout.tsx
+++ b/src/app/(main)/workspaces/layout.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { redirect } from "next/navigation";
 import { getAuthSession } from "@/lib/auth";
+import SidebarProvider from "@/components/providers/SidebarProvider";
 import LayoutWithSidebar from "@/components/layout/LayoutWithSidebar";
 
 export default async function WorkspacesLayout({
@@ -17,10 +18,10 @@ export default async function WorkspacesLayout({
 
   const pathname = "/workspaces";
   return (
-    <>
-      <LayoutWithSidebar session={session} pathname={pathname}>
+    <SidebarProvider>
+      <LayoutWithSidebar pathname={pathname}>
         <div className="mx-auto w-full h-full">{children}</div>
       </LayoutWithSidebar>
-    </>
+    </SidebarProvider>
   );
 }


### PR DESCRIPTION
## 📝 Summary
This pull request refactors the layout components for the `create-workspace` and `workspaces` pages to wrap their content with the new `SidebarProvider` component. This change ensures that any components within these layouts can access sidebar-related context or state.

Layout improvements and context management:

* Added `SidebarProvider` to wrap the content in both `create-workspace/layout.tsx` and `workspaces/layout.tsx`, enabling sidebar context for all child components. [[1]](diffhunk://#diff-1cf9a508882f512981bd7126ea533df17eef464df2e8c17366a7acafabf3bf2eR5) [[2]](diffhunk://#diff-1cf9a508882f512981bd7126ea533df17eef464df2e8c17366a7acafabf3bf2eL20-R25) [[3]](diffhunk://#diff-f1cd39c7ac5aecf59967893355c2943c6260d0ceb7ba3fb16159fab1b5b4898aR4) [[4]](diffhunk://#diff-f1cd39c7ac5aecf59967893355c2943c6260d0ceb7ba3fb16159fab1b5b4898aL20-R25)
* Removed the unnecessary `session` prop from `LayoutWithSidebar`, as it is no longer being passed in these layouts. [[1]](diffhunk://#diff-1cf9a508882f512981bd7126ea533df17eef464df2e8c17366a7acafabf3bf2eL20-R25) [[2]](diffhunk://#diff-f1cd39c7ac5aecf59967893355c2943c6260d0ceb7ba3fb16159fab1b5b4898aL20-R25)
- 

## 🔗 Related Issue(s)

<!-- Link any related issues. Example: Closes #123 -->
- 

## ✅ Test Plan

<!-- How did you test the changes? Manual/automated? -->
- [ ] Unit tests added/updated
- [ ] Application tested locally
- [ ] E2E tests run (if applicable)

## 📸 Screenshots / Demo (if applicable)

<!-- Add screenshots or demo recordings for UI changes. -->
- 

## 📋 Checklist

- [ ] Code follows the project's coding standards
- [ ] Tests pass successfully
- [ ] Documentation (README, comments) updated if needed
- [ ] I have reviewed and signed the Code of Conduct and Contribution Guidelines
