### PR TITLE
Remove sorting and lock sorting to manual

### DIFF
--- a/src/components/modals/CreateViewModal.tsx
+++ b/src/components/modals/CreateViewModal.tsx
@@ -29,7 +29,6 @@ import {
   ViewTypeSelector,
   ViewProjectSelector,
   ViewGroupingSelector,
-  ViewOrderingSelector,
   ViewDisplayPropertiesSelector,
   StatusSelector,
   PrioritySelector,
@@ -151,7 +150,7 @@ export default function CreateViewModal({
         visibility: formData.visibility as 'PERSONAL' | 'WORKSPACE' | 'SHARED',
         projectIds: formData.projectIds,
         filters: formData.filters,
-        sorting: { field: formData.ordering, direction: 'asc' },
+        sorting: { field: 'manual', direction: 'asc' },
         grouping: { field: formData.grouping },
         fields: formData.displayProperties,
         layout: {
@@ -195,7 +194,7 @@ export default function CreateViewModal({
     })();
 
     const newGrouping = newType === 'KANBAN' ? 'status' : 'none';
-    const newOrdering = newType === 'TIMELINE' ? 'startDate' : 'manual';
+    const newOrdering = 'manual';
 
     setFormData(prev => ({
       ...prev,
@@ -317,11 +316,6 @@ export default function CreateViewModal({
             <ViewGroupingSelector
               value={formData.grouping}
               onChange={(grouping) => setFormData(prev => ({ ...prev, grouping }))}
-              displayType={formData.displayType}
-            />
-            <ViewOrderingSelector
-              value={formData.ordering}
-              onChange={(ordering) => setFormData(prev => ({ ...prev, ordering }))}
               displayType={formData.displayType}
             />
             <ViewDisplayPropertiesSelector

--- a/src/components/views/renderers/KanbanViewRenderer/hooks/useKanbanState.ts
+++ b/src/components/views/renderers/KanbanViewRenderer/hooks/useKanbanState.ts
@@ -258,7 +258,7 @@ export const useKanbanState = ({
 
       // Compute neighbor context using currently rendered order
       const items = targetColumn.issues.filter((i: any) => i.id !== draggableId);
-      const destIndex = isSameColumn && destination.index > source.index ? destination.index - 1 : destination.index;
+      const destIndex = destination.index;
       const getPos = (it: any) => (it?.viewPosition ?? it?.position ?? 0);
       const prev = destIndex > 0 ? items[destIndex - 1] : undefined;
       const next = destIndex < items.length ? items[destIndex] : undefined;


### PR DESCRIPTION
## 📝 Summary


- Removed ViewOrderingSelector from CreateViewModal and ViewRenderer, enforcing a fixed sorting method of 'manual'.
- Updated state management to reflect the change in sorting logic, ensuring consistent behavior across components.
- Removes conditional adjustment of destination index when moving items within the same column, ensuring correct neighbor context computation for kanban item reordering.

## 🔗 Related Issue(s)

[CLB-166](https://teams.weezboo.com/368c2c60-7be4-49b3-b269-eee3fca60684/issues/CLB-166
)
## ✅ Test Plan

<!-- How did you test the changes? Manual/automated? -->
- [ ] Unit tests added/updated
- [ ] Application tested locally
- [ ] E2E tests run (if applicable)

## 📸 Screenshots / Demo (if applicable)

<!-- Add screenshots or demo recordings for UI changes. -->
- 

## 📋 Checklist

- [ ] Code follows the project's coding standards
- [ ] Tests pass successfully
- [ ] Documentation (README, comments) updated if needed
- [ ] I have reviewed and signed the Code of Conduct and Contribution Guidelines
