### PR TITLE
Add autofocus prop to RichEditor and comment components

### DIFF
--- a/src/components/RichEditor/IssueRichEditor.tsx
+++ b/src/components/RichEditor/IssueRichEditor.tsx
@@ -682,6 +682,7 @@ export function IssueRichEditor({
         </div>
       )}
       <RichEditor
+        autofocus={true}
         key={collabDocumentId ? `collab-${collabDocumentId}-${collabReady}` : 'nocollab'}
         ref={editorRef}
         value={value}

--- a/src/components/RichEditor/RichEditor.tsx
+++ b/src/components/RichEditor/RichEditor.tsx
@@ -89,6 +89,7 @@ export const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(({
   
   // Initialize editor with extensions
   const editor = useEditor({
+    autofocus: true,
     extensions: [
       StarterKit.configure({
         heading: {

--- a/src/components/RichEditor/RichEditor.tsx
+++ b/src/components/RichEditor/RichEditor.tsx
@@ -69,7 +69,8 @@ export const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(({
   onSelectionUpdate,
   onKeyDown,
   onUpdate,
-  additionalExtensions = []
+  additionalExtensions = [],
+  autofocus = false,
 }, ref) => {
   const { currentWorkspace } = useWorkspace();
   const { toast } = useToast();
@@ -89,7 +90,7 @@ export const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(({
   
   // Initialize editor with extensions
   const editor = useEditor({
-    autofocus: true,
+    autofocus: autofocus,
     extensions: [
       StarterKit.configure({
         heading: {

--- a/src/components/RichEditor/types/index.ts
+++ b/src/components/RichEditor/types/index.ts
@@ -17,6 +17,7 @@ export interface RichEditorProps {
   onKeyDown?: (e: React.KeyboardEvent) => void;
   onUpdate?: (editor: any) => void;
   additionalExtensions?: any[];
+  autofocus?: boolean;
 }
 
 export interface RichEditorRef {

--- a/src/components/issue/IssueDetailContent.tsx
+++ b/src/components/issue/IssueDetailContent.tsx
@@ -1184,6 +1184,7 @@ export function IssueDetailContent({
                 initialComments={(issue.comments || []) as any}
                 currentUserId={currentUserId}
                 workspaceId={workspaceId || ""}
+                autofocus={false}
               />
             </div>
           </div>

--- a/src/components/issue/sections/comments/IssueCommentsSection.tsx
+++ b/src/components/issue/sections/comments/IssueCommentsSection.tsx
@@ -14,7 +14,8 @@ export function IssueCommentsSection({
   issueId,
   initialComments = [],
   currentUserId,
-  workspaceId
+  workspaceId,
+  autofocus = false
 }: IssueCommentsSectionProps) {
   const { data: currentUser } = useCurrentUser();
   const { data: comments = [], isLoading } = useIssueComments(issueId);
@@ -64,6 +65,7 @@ export function IssueCommentsSection({
         onSubmit={handleAddComment}
         isLoading={addCommentMutation.isPending}
         workspaceId={workspaceId}
+        autofocus={autofocus}
       />
     </div>
   );

--- a/src/components/issue/sections/comments/components/CommentForm.tsx
+++ b/src/components/issue/sections/comments/components/CommentForm.tsx
@@ -13,6 +13,7 @@ export function CommentForm({
   isLoading = false,
   workspaceId,
   showUserInfo = true,
+  autofocus = false
 }: CommentFormProps) {
   const [content, setContent] = useState("");
   const { data: currentUser } = useCurrentUser();
@@ -38,6 +39,7 @@ export function CommentForm({
         toolbarMode="static"
         showAiImprove={true}
         workspaceId={workspaceId}
+        autofocus={autofocus}
       />
 
       <div className="flex justify-between">

--- a/src/components/issue/sections/comments/types/comment.ts
+++ b/src/components/issue/sections/comments/types/comment.ts
@@ -29,6 +29,7 @@ export interface IssueCommentsSectionProps {
   initialComments?: IssueComment[];
   currentUserId?: string;
   workspaceId?: string;
+  autofocus?: boolean;
 }
 
 export interface CommentItemProps {
@@ -45,4 +46,5 @@ export interface CommentFormProps {
   isLoading?: boolean;
   workspaceId?: string;
   showUserInfo?: boolean;
+  autofocus?: boolean;
 }


### PR DESCRIPTION
## 📝 Summary

Introduces an optional autofocus prop to RichEditor, IssueCommentsSection, and CommentForm components, allowing control over editor focus behavior. Updates related type definitions and propagates the prop through the component hierarchy for improved flexibility.

## 🔗 Related Issue(s)

[CLB-221](https://collab.weez.boo/368c2c60-7be4-49b3-b269-eee3fca60684/issues/CLB-221
)
## ✅ Test Plan

<!-- How did you test the changes? Manual/automated? -->
- [ ] Unit tests added/updated
- [ ] Application tested locally
- [ ] E2E tests run (if applicable)

## 📸 Screenshots / Demo (if applicable)

<!-- Add screenshots or demo recordings for UI changes. -->
- 

## 📋 Checklist

- [ ] Code follows the project's coding standards
- [ ] Tests pass successfully
- [ ] Documentation (README, comments) updated if needed
- [ ] I have reviewed and signed the Code of Conduct and Contribution Guidelines
