### PR TITLE
View owner selector removed from view options

### DIFF
--- a/src/components/views/shared/ViewFilters.tsx
+++ b/src/components/views/shared/ViewFilters.tsx
@@ -10,12 +10,10 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover';
-import { 
-  Settings,
+import {
   X,
   User,
   UserX,
-  ChevronDown,
   Globe,
   Lock,
   Trash2,
@@ -405,18 +403,6 @@ export default function ViewFilters({
                 </div>
               </PopoverContent>
             </Popover>
-          </div>
-
-          {/* Owner Selector */}
-          <div className="flex items-center justify-between">
-            <div className="text-xs text-[#9ca3af]">Owner</div>
-            <OwnerSelector
-              value={view?.owner?.id}
-              onChange={onOwnerChange}
-              workspaceMembers={workspaceMembers}
-              currentOwner={view?.owner}
-              isLoading={isLoadingMembers}
-            />
           </div>
         </div>
         


### PR DESCRIPTION
## 📝 Summary
This pull request makes a minor update to the `ViewFilters` component by removing the Owner Selector UI and its associated imports. This simplifies the filter options available to users.

UI cleanup:

* Removed the Owner Selector section from the `ViewFilters` component, including the associated `OwnerSelector` usage and related imports such as `Settings` and `ChevronDown` icons. [[1]](diffhunk://#diff-f5045efa93ef4bbf6a26751107f94aadd46a3fc29040ae0da60677d7ee71c274L14-L18) [[2]](diffhunk://#diff-f5045efa93ef4bbf6a26751107f94aadd46a3fc29040ae0da60677d7ee71c274L409-L420)
- 

## 🔗 Related Issue(s)

<!-- Link any related issues. Example: Closes #123 -->
- 

## ✅ Test Plan

<!-- How did you test the changes? Manual/automated? -->
- [ ] Unit tests added/updated
- [ ] Application tested locally
- [ ] E2E tests run (if applicable)

## 📸 Screenshots / Demo (if applicable)

<!-- Add screenshots or demo recordings for UI changes. -->
- 

## 📋 Checklist

- [ ] Code follows the project's coding standards
- [ ] Tests pass successfully
- [ ] Documentation (README, comments) updated if needed
- [ ] I have reviewed and signed the Code of Conduct and Contribution Guidelines
